### PR TITLE
Atualizar UI para seleção de pastas e listagem de arquivos

### DIFF
--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from PyQt6.QtWidgets import QMessageBox
 
 from .config_manager import ConfigManager
-from .image_manager import ImageManager, MEDIA_EXTENSIONS
+from .image_manager import ImageManager
 from ui.main_window import MainWindow
 
 
@@ -21,8 +21,10 @@ class AppController:
         self.window.settingsTab.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
         self.window.browseFolderRequested.connect(self._on_browse_folder)
-        self.window.outputBrowseRequested.connect(self._on_browse_output)
         self.window.configRequested.connect(self._open_settings_tab)
+        self.window.settingsTab.outputFolderBrowseRequested.connect(
+            self._on_browse_output
+        )
 
         self._initialize_state()
 
@@ -38,20 +40,13 @@ class AppController:
             output_path = Path(output_folder)
             if output_path.exists():
                 self.output_directory = output_path
-                self.window.set_output_folder(output_path)
-                self._refresh_output_files()
+                self.window.settingsTab.set_output_folder(output_path)
             else:
                 self.output_directory = None
-                self.window.clear_output_folder()
-                self.window.set_output_files([])
-                self.window.update_output_status(
-                    "A pasta de destino configurada não existe mais. Selecione outra pasta."
-                )
+                self.window.settingsTab.set_output_folder(None)
         else:
             self.output_directory = None
-            self.window.clear_output_folder()
-            self.window.set_output_files([])
-            self.window.update_output_status("Nenhuma pasta de destino selecionada.")
+            self.window.settingsTab.set_output_folder(None)
 
         recent = self.config_manager.recent_folders()
         if recent:
@@ -67,11 +62,12 @@ class AppController:
         self.window.apply_config(namespace, self.config_manager.data.get(namespace, {}))
 
     def _on_prompt_submitted(self, prompt: str) -> None:
-        message = (
+        QMessageBox.information(
+            self.window,
+            "Prompt recebido",
             "Prompt recebido! Configure suas opções e utilize as integrações de IA "
-            "para gerar o conteúdo desejado."
+            "para gerar o conteúdo desejado.",
         )
-        self.window.update_output_status(message)
         self.window.clear_prompt()
 
     def _on_browse_folder(self) -> None:
@@ -87,9 +83,8 @@ class AppController:
         if folder is None:
             return
         self.output_directory = folder
-        self.window.set_output_folder(folder)
+        self.window.settingsTab.set_output_folder(folder)
         self.config_manager.update("paths", "output_folder", str(folder))
-        self._refresh_output_files()
 
     def _open_settings_tab(self) -> None:
         index = self.window.tabs.indexOf(self.window.settingsTab)
@@ -122,19 +117,3 @@ class AppController:
         self.window.update_source_status(message)
         self.window.set_path_label(folder)
 
-    def _refresh_output_files(self) -> None:
-        if self.output_directory is None or not self.output_directory.exists():
-            self.window.set_output_files([])
-            self.window.update_output_status("Nenhuma pasta de destino selecionada.")
-            return
-
-        files = [
-            path
-            for path in sorted(self.output_directory.iterdir())
-            if path.is_file() and path.suffix.lower() in MEDIA_EXTENSIONS
-        ]
-        self.window.set_output_files(files)
-        if not files:
-            self.window.update_output_status(
-                "Nenhum arquivo encontrado na pasta de destino selecionada."
-            )

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -16,11 +16,13 @@ class AppController:
         self.image_manager = ImageManager()
         self.window = MainWindow()
 
+        self.output_directory: Path | None = None
+
         self.window.configPanel.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
         self.window.browseFolderRequested.connect(self._on_browse_folder)
+        self.window.outputBrowseRequested.connect(self._on_browse_output)
         self.window.configRequested.connect(self._open_settings_tab)
-        self.window.sidebar.folderSelected.connect(self._on_folder_selected)
 
         self._initialize_state()
 
@@ -31,21 +33,25 @@ class AppController:
     def _initialize_state(self) -> None:
         image_config = self.config_manager.data.get("image", {})
         self.window.apply_config("image", image_config)
+        output_folder = self.config_manager.get("paths", "output_folder", "")
+        if isinstance(output_folder, str) and output_folder:
+            output_path = Path(output_folder)
+            if output_path.exists():
+                self.output_directory = output_path
+                self.window.set_output_folder(output_path)
+            else:
+                self.window.clear_output_folder()
+        else:
+            self.window.clear_output_folder()
+
         recent = self.config_manager.recent_folders()
         if recent:
-            self.window.set_directories(recent)
-            self.window.select_directory(recent[0])
-            self._load_directory(recent[0])
+            self._select_directory(recent[0])
         else:
-            self._refresh_directories()
-            self.window.update_left_viewer(
-                "Nenhuma pasta selecionada",
-                "Use o painel lateral para escolher uma pasta de imagens.",
+            self.window.set_source_files([])
+            self.window.update_source_status(
+                "Nenhuma pasta selecionada. Use o botão acima para escolher uma pasta.",
             )
-
-    def _refresh_directories(self) -> None:
-        directories = self.image_manager.list_directories()
-        self.window.set_directories(directories)
 
     def _on_option_changed(self, namespace: str, key: str, value) -> None:
         self.config_manager.update(namespace, key, value)
@@ -66,13 +72,19 @@ class AppController:
             return
         self._select_directory(folder)
 
+    def _on_browse_output(self) -> None:
+        start = self.output_directory or self.image_manager.root_path
+        folder = self.window.open_folder_dialog(start)
+        if folder is None:
+            return
+        self.output_directory = folder
+        self.window.set_output_folder(folder)
+        self.config_manager.update("paths", "output_folder", str(folder))
+
     def _open_settings_tab(self) -> None:
         index = self.window.tabs.indexOf(self.window.settingsTab)
         if index >= 0:
             self.window.tabs.setCurrentIndex(index)
-
-    def _on_folder_selected(self, folder: Path) -> None:
-        self._select_directory(folder)
 
     def _select_directory(self, folder: Path) -> None:
         try:
@@ -85,13 +97,17 @@ class AppController:
             )
             return
         self.config_manager.add_recent_folder(folder)
-        self.window.set_directories(self.config_manager.recent_folders())
-        self.window.select_directory(folder)
         self._load_directory(folder)
 
     def _load_directory(self, folder: Path) -> None:
-        images = self.image_manager.list_images()
-        self.window.set_gallery_images(images)
-        message = f"{len(images)} arquivo(s) de imagem encontrado(s)"
-        self.window.update_left_viewer(folder.name or str(folder), message)
+        files = self.image_manager.list_media_files()
+        self.window.set_source_folder(folder)
+        self.window.set_source_files(files)
+        if files:
+            message = f"{len(files)} arquivo(s) encontrado(s)"
+        else:
+            message = (
+                "Nenhum arquivo de imagem ou texto encontrado na pasta selecionada."
+            )
+        self.window.update_source_status(message)
         self.window.set_path_label(folder)

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from PyQt6.QtWidgets import QMessageBox
 
 from .config_manager import ConfigManager
-from .image_manager import ImageManager
+from .image_manager import ImageManager, MEDIA_EXTENSIONS
 from ui.main_window import MainWindow
 
 
@@ -18,7 +18,7 @@ class AppController:
 
         self.output_directory: Path | None = None
 
-        self.window.configPanel.optionChanged.connect(self._on_option_changed)
+        self.window.settingsTab.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
         self.window.browseFolderRequested.connect(self._on_browse_folder)
         self.window.outputBrowseRequested.connect(self._on_browse_output)
@@ -39,10 +39,19 @@ class AppController:
             if output_path.exists():
                 self.output_directory = output_path
                 self.window.set_output_folder(output_path)
+                self._refresh_output_files()
             else:
+                self.output_directory = None
                 self.window.clear_output_folder()
+                self.window.set_output_files([])
+                self.window.update_output_status(
+                    "A pasta de destino configurada não existe mais. Selecione outra pasta."
+                )
         else:
+            self.output_directory = None
             self.window.clear_output_folder()
+            self.window.set_output_files([])
+            self.window.update_output_status("Nenhuma pasta de destino selecionada.")
 
         recent = self.config_manager.recent_folders()
         if recent:
@@ -62,7 +71,7 @@ class AppController:
             "Prompt recebido! Configure suas opções e utilize as integrações de IA "
             "para gerar o conteúdo desejado."
         )
-        self.window.update_right_viewer("Pronto para gerar", message)
+        self.window.update_output_status(message)
         self.window.clear_prompt()
 
     def _on_browse_folder(self) -> None:
@@ -80,6 +89,7 @@ class AppController:
         self.output_directory = folder
         self.window.set_output_folder(folder)
         self.config_manager.update("paths", "output_folder", str(folder))
+        self._refresh_output_files()
 
     def _open_settings_tab(self) -> None:
         index = self.window.tabs.indexOf(self.window.settingsTab)
@@ -111,3 +121,20 @@ class AppController:
             )
         self.window.update_source_status(message)
         self.window.set_path_label(folder)
+
+    def _refresh_output_files(self) -> None:
+        if self.output_directory is None or not self.output_directory.exists():
+            self.window.set_output_files([])
+            self.window.update_output_status("Nenhuma pasta de destino selecionada.")
+            return
+
+        files = [
+            path
+            for path in sorted(self.output_directory.iterdir())
+            if path.is_file() and path.suffix.lower() in MEDIA_EXTENSIONS
+        ]
+        self.window.set_output_files(files)
+        if not files:
+            self.window.update_output_status(
+                "Nenhum arquivo encontrado na pasta de destino selecionada."
+            )

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -21,7 +21,6 @@ class AppController:
         self.window.settingsTab.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
         self.window.browseFolderRequested.connect(self._on_browse_folder)
-        self.window.configRequested.connect(self._open_settings_tab)
         self.window.settingsTab.outputFolderBrowseRequested.connect(
             self._on_browse_output
         )
@@ -86,11 +85,6 @@ class AppController:
         self.window.settingsTab.set_output_folder(folder)
         self.config_manager.update("paths", "output_folder", str(folder))
 
-    def _open_settings_tab(self) -> None:
-        index = self.window.tabs.indexOf(self.window.settingsTab)
-        if index >= 0:
-            self.window.tabs.setCurrentIndex(index)
-
     def _select_directory(self, folder: Path) -> None:
         try:
             self.image_manager.set_current_directory(folder)
@@ -115,5 +109,4 @@ class AppController:
                 "Nenhum arquivo de imagem ou texto encontrado na pasta selecionada."
             )
         self.window.update_source_status(message)
-        self.window.set_path_label(folder)
 

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -20,6 +20,9 @@ def _default_config() -> Dict[str, Any]:
             "type": "Imagem",
         },
         "recent_folders": [],
+        "paths": {
+            "output_folder": "",
+        },
     }
 
 

--- a/core/image_manager.py
+++ b/core/image_manager.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import List, Sequence
 
 IMAGE_EXTENSIONS: Sequence[str] = (".png", ".jpg", ".jpeg", ".webp", ".bmp")
+TEXT_EXTENSIONS: Sequence[str] = (".txt",)
+MEDIA_EXTENSIONS: Sequence[str] = IMAGE_EXTENSIONS + TEXT_EXTENSIONS
 
 
 @dataclass
@@ -48,6 +50,16 @@ class ImageManager:
             file
             for file in sorted(base.iterdir())
             if file.is_file() and file.suffix.lower() in IMAGE_EXTENSIONS
+        ]
+
+    def list_media_files(self) -> List[Path]:
+        base = self.current_directory or self.root_path
+        if not base.exists():
+            return []
+        return [
+            file
+            for file in sorted(base.iterdir())
+            if file.is_file() and file.suffix.lower() in MEDIA_EXTENSIONS
         ]
 
     def latest_images(self, limit: int = 10) -> List[Path]:

--- a/ui/config_panel.py
+++ b/ui/config_panel.py
@@ -1,10 +1,12 @@
 """Panel with generation options."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict, Iterable
 
-from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
+    QHBoxLayout,
     QComboBox,
     QFormLayout,
     QGroupBox,
@@ -19,17 +21,17 @@ class ConfigPanel(QWidget):
     """Expose controls for generation parameters."""
 
     optionChanged = pyqtSignal(str, str, object)
+    outputFolderBrowseRequested = pyqtSignal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self._destination_path: str | None = None
         self._setup_ui()
 
     def _setup_ui(self) -> None:
         layout = QVBoxLayout(self)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(12)
-
-        layout.addWidget(QLabel("Configurações de geração"))
 
         self.sizeCombo = self._create_combo(
             [
@@ -55,6 +57,25 @@ class ConfigPanel(QWidget):
         form.addRow("Resolução", self.resolutionCombo)
         form.addRow("Quantidade", quantityBox)
         form.addRow("Tipo", self.typeCombo)
+
+        destination_container = QWidget()
+        destination_layout = QHBoxLayout(destination_container)
+        destination_layout.setContentsMargins(0, 0, 0, 0)
+        destination_layout.setSpacing(8)
+
+        destination_label = QLabel("Nenhuma pasta selecionada.")
+        destination_label.setWordWrap(True)
+        destination_label.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft)
+        destination_layout.addWidget(destination_label, 1)
+
+        browse_button = QPushButton("Selecionar…")
+        browse_button.clicked.connect(self.outputFolderBrowseRequested.emit)
+        destination_layout.addWidget(browse_button)
+
+        self.destinationLabel = destination_label
+        self.destinationButton = browse_button
+
+        form.addRow("Destino", destination_container)
 
         group = QGroupBox()
         group.setLayout(form)
@@ -100,3 +121,26 @@ class ConfigPanel(QWidget):
             index = self.typeCombo.findText(item_type)
             if index >= 0:
                 self.typeCombo.setCurrentIndex(index)
+
+    def set_output_folder(self, folder: Path | str | None) -> None:
+        if folder is None:
+            self._destination_path = None
+            self.destinationLabel.setText("Nenhuma pasta selecionada.")
+            return
+
+        text = str(folder)
+        self._destination_path = text
+        metrics = self.destinationLabel.fontMetrics()
+        available_width = max(0, self.destinationLabel.width())
+        if available_width:
+            elided = metrics.elidedText(text, Qt.TextElideMode.ElideMiddle, available_width)
+            self.destinationLabel.setText(elided)
+        else:
+            self.destinationLabel.setText(text)
+
+    def resizeEvent(self, event):  # type: ignore[override]
+        super().resizeEvent(event)
+        if self._destination_path is None:
+            self.destinationLabel.setText("Nenhuma pasta selecionada.")
+        else:
+            self.set_output_folder(self._destination_path)

--- a/ui/config_panel.py
+++ b/ui/config_panel.py
@@ -14,6 +14,7 @@ from PyQt6.QtWidgets import (
     QSpinBox,
     QVBoxLayout,
     QWidget,
+    QPushButton,
 )
 
 

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -33,7 +33,6 @@ class MainWindow(QMainWindow):
 
     promptSubmitted = pyqtSignal(str)
     browseFolderRequested = pyqtSignal()
-    outputBrowseRequested = pyqtSignal()
     configRequested = pyqtSignal()
 
     IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
@@ -99,24 +98,8 @@ class MainWindow(QMainWindow):
 
         splitter.addWidget(center)
 
-        right = QWidget()
-        right_layout = QVBoxLayout(right)
-        right_layout.setContentsMargins(12, 16, 16, 16)
-        right_layout.setSpacing(12)
-        self.outputPanel = self._create_file_panel(
-            title="Arquivos da pasta de destino",
-            browse_text="Selecionar pasta de saída…",
-            browse_slot=self.outputBrowseRequested.emit,
-            status_text="Os arquivos salvos serão exibidos aqui.",
-            object_name="OutputPanel",
-            enable_selection=False,
-        )
-        right_layout.addWidget(self.outputPanel, 1)
-        splitter.addWidget(right)
-
         splitter.setStretchFactor(0, 2)
         splitter.setStretchFactor(1, 3)
-        splitter.setStretchFactor(2, 2)
 
         self._apply_thumbnail_size(self._image_icon_size)
 
@@ -154,7 +137,7 @@ class MainWindow(QMainWindow):
         frame.setObjectName(object_name)
         layout = QVBoxLayout(frame)
         layout.setContentsMargins(12, 12, 12, 12)
-        layout.setSpacing(10)
+        layout.setSpacing(8)
 
         title_label = QLabel(title)
         title_label.setObjectName(f"{object_name}Title")
@@ -194,9 +177,9 @@ class MainWindow(QMainWindow):
         text_list.setResizeMode(QListView.ResizeMode.Adjust)
         text_list.setMovement(QListView.Movement.Static)
         text_list.setWrapping(True)
-        text_list.setSpacing(4)
+        text_list.setSpacing(2)
         text_list.setWordWrap(True)
-        text_list.setGridSize(QSize(self._text_tile_width, 52))
+        text_list.setGridSize(QSize(self._text_tile_width, 38))
         layout.addWidget(text_list)
 
         image_list = QListWidget()
@@ -206,7 +189,7 @@ class MainWindow(QMainWindow):
         image_list.setResizeMode(QListView.ResizeMode.Adjust)
         image_list.setMovement(QListView.Movement.Static)
         image_list.setWrapping(True)
-        image_list.setSpacing(8)
+        image_list.setSpacing(4)
         image_list.setWordWrap(True)
         image_list.setUniformItemSizes(False)
         layout.addWidget(image_list, 1)
@@ -235,25 +218,44 @@ class MainWindow(QMainWindow):
         description.setWordWrap(True)
         layout.addWidget(description)
 
-        list_widget = QListWidget()
-        list_widget.setObjectName("SelectedFileList")
-        list_widget.setViewMode(QListView.ViewMode.IconMode)
-        list_widget.setResizeMode(QListView.ResizeMode.Adjust)
-        list_widget.setMovement(QListView.Movement.Static)
-        list_widget.setWrapping(True)
-        list_widget.setSpacing(8)
-        list_widget.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
-        list_widget.setIconSize(QSize(self._image_icon_size, self._image_icon_size))
-        list_widget.setGridSize(QSize(self._image_icon_size + 40, self._image_icon_size + 56))
-        layout.addWidget(list_widget, 1)
+        text_list = QListWidget()
+        text_list.setObjectName("SelectedTextList")
+        text_list.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
+        text_list.setViewMode(QListView.ViewMode.IconMode)
+        text_list.setResizeMode(QListView.ResizeMode.Adjust)
+        text_list.setMovement(QListView.Movement.Static)
+        text_list.setWrapping(True)
+        text_list.setSpacing(2)
+        text_list.setWordWrap(True)
+        text_list.setGridSize(QSize(self._text_tile_width, 38))
+        layout.addWidget(text_list)
+
+        image_list = QListWidget()
+        image_list.setObjectName("SelectedImageList")
+        image_list.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
+        image_list.setViewMode(QListView.ViewMode.IconMode)
+        image_list.setResizeMode(QListView.ResizeMode.Adjust)
+        image_list.setMovement(QListView.Movement.Static)
+        image_list.setWrapping(True)
+        image_list.setSpacing(4)
+        image_list.setWordWrap(True)
+        image_list.setIconSize(QSize(self._image_icon_size, self._image_icon_size))
+        image_list.setGridSize(QSize(self._image_icon_size + 20, self._image_icon_size + 32))
+        layout.addWidget(image_list, 1)
 
         remove_button = QPushButton("Remover selecionados")
         remove_button.clicked.connect(self._remove_selected_items)
         layout.addWidget(remove_button)
 
-        list_widget.itemDoubleClicked.connect(self._remove_single_selected_item)
+        text_list.itemDoubleClicked.connect(
+            lambda item, list_widget=text_list: self._remove_selected_item(item, list_widget)
+        )
+        image_list.itemDoubleClicked.connect(
+            lambda item, list_widget=image_list: self._remove_selected_item(item, list_widget)
+        )
 
-        widget.listWidget = list_widget  # type: ignore[attr-defined]
+        widget.textList = text_list  # type: ignore[attr-defined]
+        widget.imageList = image_list  # type: ignore[attr-defined]
         widget.removeButton = remove_button  # type: ignore[attr-defined]
         return widget
 
@@ -263,9 +265,6 @@ class MainWindow(QMainWindow):
         layout = QVBoxLayout(frame)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(8)
-
-        label = QLabel("Prompt ou instruções")
-        layout.addWidget(label)
 
         self.promptEdit = QTextEdit()
         self.promptEdit.setPlaceholderText("Descreva aqui o que deseja gerar…")
@@ -309,28 +308,6 @@ class MainWindow(QMainWindow):
                 if image_count:
                     parts.append(
                         f"{image_count} imagem{'s' if image_count != 1 else ''} encontrada"
-                    )
-                if text_count:
-                    parts.append(
-                        f"{text_count} arquivo{'s' if text_count != 1 else ''} de texto"
-                    )
-                status_label.setText(" • ".join(parts))
-
-    def set_output_files(self, files: Iterable[Path]) -> None:
-        status_label: QLabel | None = getattr(self.outputPanel, "statusLabel", None)
-        image_count, text_count = self._populate_panel_files(self.outputPanel, files)
-
-        self._refresh_image_captions(self.outputPanel)
-        self._refresh_text_captions(self.outputPanel)
-
-        if status_label is not None:
-            if image_count == 0 and text_count == 0:
-                status_label.setText("Nenhum arquivo encontrado na pasta de destino.")
-            else:
-                parts: list[str] = []
-                if image_count:
-                    parts.append(
-                        f"{image_count} imagem{'s' if image_count != 1 else ''} disponível"
                     )
                 if text_count:
                     parts.append(
@@ -383,21 +360,18 @@ class MainWindow(QMainWindow):
     def _update_thumbnail_size(self, value: int) -> None:
         self._apply_thumbnail_size(value)
         self._refresh_image_captions(self.sourcePanel)
-        self._refresh_image_captions(self.outputPanel)
         self._refresh_selected_captions()
 
     def _apply_thumbnail_size(self, size: int) -> None:
         self._image_icon_size = size
         icon_extent = QSize(size, size)
-        grid_width = size + 40
-        grid_height = size + 56
+        grid_width = size + 20
+        grid_height = size + 32
 
-        panels = [getattr(self, "sourcePanel", None), getattr(self, "outputPanel", None)]
-        for panel in panels:
-            if panel is None:
-                continue
-            image_list: QListWidget | None = getattr(panel, "imageList", None)
-            slider: QSlider | None = getattr(panel, "thumbnailSlider", None)
+        source_panel = getattr(self, "sourcePanel", None)
+        if source_panel is not None:
+            image_list: QListWidget | None = getattr(source_panel, "imageList", None)
+            slider: QSlider | None = getattr(source_panel, "thumbnailSlider", None)
             if image_list is not None:
                 image_list.setIconSize(icon_extent)
                 image_list.setGridSize(QSize(grid_width, grid_height))
@@ -407,20 +381,16 @@ class MainWindow(QMainWindow):
                 slider.blockSignals(False)
 
         selected_tab = getattr(self, "selectedTab", None)
-        selected_list: QListWidget | None = (
-            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
-        )
-        if selected_list is not None:
-            selected_list.setIconSize(icon_extent)
-            selected_list.setGridSize(QSize(grid_width, grid_height))
-            source_panel = getattr(self, "sourcePanel", None)
-            spacing_reference = None
-            if source_panel is not None:
-                source_images: QListWidget | None = getattr(source_panel, "imageList", None)
+        if selected_tab is not None:
+            image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+            if image_list is not None:
+                image_list.setIconSize(icon_extent)
+                image_list.setGridSize(QSize(grid_width, grid_height))
+                source_images: QListWidget | None = (
+                    getattr(source_panel, "imageList", None) if source_panel is not None else None
+                )
                 if source_images is not None:
-                    spacing_reference = source_images.spacing()
-            if spacing_reference is not None:
-                selected_list.setSpacing(spacing_reference)
+                    image_list.setSpacing(source_images.spacing())
 
     def _refresh_image_captions(self, panel: QWidget | None = None) -> None:
         image_list: QListWidget | None = None
@@ -446,13 +416,16 @@ class MainWindow(QMainWindow):
 
     def _refresh_selected_captions(self) -> None:
         selected_tab = getattr(self, "selectedTab", None)
-        selected_list: QListWidget | None = (
-            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
-        )
-        if selected_list is None:
+        if selected_tab is None:
             return
-        available_width = selected_list.gridSize().width() - 24
-        self._refresh_list_labels(selected_list, available_width)
+        text_list: QListWidget | None = getattr(selected_tab, "textList", None)
+        image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+        if text_list is not None:
+            available_text_width = text_list.gridSize().width() - 12
+            self._refresh_list_labels(text_list, available_text_width)
+        if image_list is not None:
+            available_image_width = image_list.gridSize().width() - 24
+            self._refresh_list_labels(image_list, available_image_width)
 
     def _refresh_list_labels(self, list_widget: QListWidget, width: int) -> None:
         if width <= 0:
@@ -474,11 +447,10 @@ class MainWindow(QMainWindow):
 
     def _add_selected_file(self, path: Path) -> None:
         selected_tab = getattr(self, "selectedTab", None)
-        selected_list: QListWidget | None = (
-            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
-        )
-        if selected_list is None:
+        if selected_tab is None:
             return
+        text_list: QListWidget | None = getattr(selected_tab, "textList", None)
+        image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
         path_str = str(path)
         if path_str in self._selected_paths:
             self.tabs.setCurrentWidget(self.selectedTab)
@@ -495,43 +467,38 @@ class MainWindow(QMainWindow):
             pixmap = QPixmap(path_str)
             if not pixmap.isNull():
                 thumbnail = pixmap.scaled(
-                    selected_list.iconSize(),
+                    image_list.iconSize() if image_list is not None else QSize(self._image_icon_size, self._image_icon_size),
                     Qt.AspectRatioMode.KeepAspectRatio,
                     Qt.TransformationMode.SmoothTransformation,
                 )
                 item.setIcon(QIcon(thumbnail))
-
-        selected_list.addItem(item)
+            if image_list is not None:
+                image_list.addItem(item)
+        else:
+            if text_list is not None:
+                text_list.addItem(item)
         self._selected_paths.add(path_str)
         self._refresh_selected_captions()
         self.tabs.setCurrentWidget(self.selectedTab)
 
     def _remove_selected_items(self) -> None:
         selected_tab = getattr(self, "selectedTab", None)
-        selected_list: QListWidget | None = (
-            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
-        )
-        if selected_list is None:
+        if selected_tab is None:
             return
-        for item in selected_list.selectedItems():
-            self._remove_selected_item(item)
+        text_list: QListWidget | None = getattr(selected_tab, "textList", None)
+        image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+        lists = [lst for lst in (text_list, image_list) if lst is not None]
+        for lst in lists:
+            for item in lst.selectedItems():
+                self._remove_selected_item(item, lst)
 
-    def _remove_single_selected_item(self, item: QListWidgetItem) -> None:
-        self._remove_selected_item(item)
-
-    def _remove_selected_item(self, item: QListWidgetItem) -> None:
-        selected_tab = getattr(self, "selectedTab", None)
-        selected_list: QListWidget | None = (
-            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
-        )
-        if selected_list is None:
-            return
+    def _remove_selected_item(self, item: QListWidgetItem, list_widget: QListWidget) -> None:
         path_data = item.data(Qt.ItemDataRole.UserRole + 1)
         if path_data:
             path_str = str(path_data)
             if path_str in self._selected_paths:
                 self._selected_paths.remove(path_str)
-        selected_list.takeItem(selected_list.row(item))
+        list_widget.takeItem(list_widget.row(item))
         self._refresh_selected_captions()
 
     def update_source_status(self, message: str) -> None:
@@ -542,21 +509,6 @@ class MainWindow(QMainWindow):
     def apply_config(self, namespace: str, data: dict[str, object]) -> None:
         if namespace == "image":
             self.settingsTab.apply_config(namespace, data)
-
-    def set_output_folder(self, folder: Path) -> None:
-        path_label = getattr(self.outputPanel, "pathLabel", None)
-        if path_label is not None:
-            path_label.setText(str(folder))
-
-    def clear_output_folder(self) -> None:
-        path_label = getattr(self.outputPanel, "pathLabel", None)
-        if path_label is not None:
-            path_label.setText("Nenhuma pasta selecionada.")
-
-    def update_output_status(self, message: str) -> None:
-        status_label = getattr(self.outputPanel, "statusLabel", None)
-        if status_label is not None:
-            status_label.setText(message)
 
     def prompt_text(self) -> str:
         return self.promptEdit.toPlainText()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Callable, Iterable
 
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import QSize, Qt, pyqtSignal
+from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtWidgets import (
     QFileDialog,
     QFrame,
@@ -186,6 +187,7 @@ class MainWindow(QMainWindow):
         file_list = QListWidget()
         file_list.setObjectName("SourceFileList")
         file_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
+        file_list.setIconSize(QSize(112, 112))
         layout.addWidget(file_list, 1)
 
         frame.pathLabel = path_label  # type: ignore[attr-defined]
@@ -238,6 +240,16 @@ class MainWindow(QMainWindow):
         for file in files:
             item = QListWidgetItem(file.name)
             item.setToolTip(str(file))
+            suffix = file.suffix.lower()
+            if suffix in {".png", ".jpg", ".jpeg", ".webp", ".bmp"}:
+                pixmap = QPixmap(str(file))
+                if not pixmap.isNull():
+                    thumbnail = pixmap.scaled(
+                        file_list.iconSize(),
+                        Qt.AspectRatioMode.KeepAspectRatio,
+                        Qt.TransformationMode.SmoothTransformation,
+                    )
+                    item.setIcon(QIcon(thumbnail))
             file_list.addItem(item)
             count += 1
         file_list.setEnabled(count > 0)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from math import ceil
 from typing import Callable, Iterable
 
-from PyQt6.QtCore import QSize, Qt, pyqtSignal
+from PyQt6.QtCore import QEvent, QSize, Qt, pyqtSignal
 from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtWidgets import (
     QFileDialog,
@@ -33,7 +34,6 @@ class MainWindow(QMainWindow):
 
     promptSubmitted = pyqtSignal(str)
     browseFolderRequested = pyqtSignal()
-    configRequested = pyqtSignal()
 
     IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
     TEXT_EXTENSIONS = {".txt"}
@@ -45,6 +45,7 @@ class MainWindow(QMainWindow):
         self._image_icon_size = 128
         self._text_tile_width = 220
         self._selected_paths: set[str] = set()
+        self._text_lists: list[QListWidget] = []
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -53,9 +54,6 @@ class MainWindow(QMainWindow):
         root = QVBoxLayout(central)
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
-
-        self.topbar = self._create_topbar()
-        root.addWidget(self.topbar)
 
         splitter = QSplitter(Qt.Orientation.Horizontal)
         splitter.setChildrenCollapsible(False)
@@ -102,26 +100,6 @@ class MainWindow(QMainWindow):
         splitter.setStretchFactor(1, 3)
 
         self._apply_thumbnail_size(self._image_icon_size)
-
-    def _create_topbar(self) -> QWidget:
-        frame = QFrame()
-        frame.setObjectName("TopBar")
-        layout = QHBoxLayout(frame)
-        layout.setContentsMargins(16, 12, 16, 12)
-        layout.setSpacing(12)
-
-        self.brandLabel = QLabel("Image Studio IA")
-        self.brandLabel.setObjectName("BrandLabel")
-        layout.addWidget(self.brandLabel)
-
-        self.pathLabel = QLabel("Pasta: —")
-        self.pathLabel.setObjectName("PathLabel")
-        layout.addWidget(self.pathLabel, 1)
-
-        self.configButton = QPushButton("Configurações")
-        self.configButton.clicked.connect(self.configRequested.emit)
-        layout.addWidget(self.configButton)
-        return frame
 
     def _create_file_panel(
         self,
@@ -189,7 +167,7 @@ class MainWindow(QMainWindow):
         image_list.setResizeMode(QListView.ResizeMode.Adjust)
         image_list.setMovement(QListView.Movement.Static)
         image_list.setWrapping(True)
-        image_list.setSpacing(4)
+        image_list.setSpacing(3)
         image_list.setWordWrap(True)
         image_list.setUniformItemSizes(False)
         layout.addWidget(image_list, 1)
@@ -199,6 +177,10 @@ class MainWindow(QMainWindow):
         frame.imageList = image_list  # type: ignore[attr-defined]
         frame.pathLabel = path_label  # type: ignore[attr-defined]
         frame.statusLabel = status  # type: ignore[attr-defined]
+
+        text_list.setVisible(False)
+        text_list.setSizeAdjustPolicy(QListView.SizeAdjustPolicy.AdjustToContents)
+        self._register_text_list(text_list)
 
         if enable_selection:
             text_list.itemDoubleClicked.connect(self._handle_source_double_click)
@@ -237,10 +219,15 @@ class MainWindow(QMainWindow):
         image_list.setResizeMode(QListView.ResizeMode.Adjust)
         image_list.setMovement(QListView.Movement.Static)
         image_list.setWrapping(True)
-        image_list.setSpacing(4)
+        image_list.setSpacing(3)
         image_list.setWordWrap(True)
         image_list.setIconSize(QSize(self._image_icon_size, self._image_icon_size))
-        image_list.setGridSize(QSize(self._image_icon_size + 20, self._image_icon_size + 32))
+        image_list.setGridSize(
+            QSize(
+                max(self._image_icon_size + 8, int(self._image_icon_size * 1.05)),
+                self._image_icon_size + 28,
+            )
+        )
         layout.addWidget(image_list, 1)
 
         remove_button = QPushButton("Remover selecionados")
@@ -257,6 +244,10 @@ class MainWindow(QMainWindow):
         widget.textList = text_list  # type: ignore[attr-defined]
         widget.imageList = image_list  # type: ignore[attr-defined]
         widget.removeButton = remove_button  # type: ignore[attr-defined]
+
+        text_list.setVisible(False)
+        text_list.setSizeAdjustPolicy(QListView.SizeAdjustPolicy.AdjustToContents)
+        self._register_text_list(text_list)
         return widget
 
     def _create_composer(self) -> QWidget:
@@ -284,9 +275,6 @@ class MainWindow(QMainWindow):
             self.promptSubmitted.emit(text)
 
     # Public helpers -----------------------------------------------------
-    def set_path_label(self, path: Path) -> None:
-        self.pathLabel.setText(f"Pasta: {path}")
-
     def set_source_folder(self, folder: Path) -> None:
         path_label = getattr(self.sourcePanel, "pathLabel", None)
         if path_label is not None:
@@ -355,6 +343,7 @@ class MainWindow(QMainWindow):
 
         image_list.setEnabled(image_count > 0)
         text_list.setEnabled(text_count > 0)
+        self._adjust_text_list_height(text_list)
         return image_count, text_count
 
     def _update_thumbnail_size(self, value: int) -> None:
@@ -365,8 +354,8 @@ class MainWindow(QMainWindow):
     def _apply_thumbnail_size(self, size: int) -> None:
         self._image_icon_size = size
         icon_extent = QSize(size, size)
-        grid_width = size + 20
-        grid_height = size + 32
+        grid_width = max(size + 8, int(size * 1.05))
+        grid_height = size + 28
 
         source_panel = getattr(self, "sourcePanel", None)
         if source_panel is not None:
@@ -477,6 +466,7 @@ class MainWindow(QMainWindow):
         else:
             if text_list is not None:
                 text_list.addItem(item)
+                self._adjust_text_list_height(text_list)
         self._selected_paths.add(path_str)
         self._refresh_selected_captions()
         self.tabs.setCurrentWidget(self.selectedTab)
@@ -499,6 +489,8 @@ class MainWindow(QMainWindow):
             if path_str in self._selected_paths:
                 self._selected_paths.remove(path_str)
         list_widget.takeItem(list_widget.row(item))
+        if list_widget in self._text_lists:
+            self._adjust_text_list_height(list_widget)
         self._refresh_selected_captions()
 
     def update_source_status(self, message: str) -> None:
@@ -526,3 +518,33 @@ class MainWindow(QMainWindow):
             if selected:
                 return Path(selected[0])
         return None
+
+    def _register_text_list(self, list_widget: QListWidget) -> None:
+        self._text_lists.append(list_widget)
+        list_widget.installEventFilter(self)
+
+    def _adjust_text_list_height(self, list_widget: QListWidget | None) -> None:
+        if list_widget is None:
+            return
+        count = list_widget.count()
+        if count == 0:
+            list_widget.setVisible(False)
+            list_widget.setFixedHeight(0)
+            return
+
+        list_widget.setVisible(True)
+        grid_size = list_widget.gridSize()
+        grid_width = grid_size.width() or list_widget.viewport().width()
+        grid_height = grid_size.height() or list_widget.sizeHintForRow(0) or 38
+
+        viewport_width = list_widget.viewport().width() or grid_width
+        columns = max(1, viewport_width // max(grid_width, 1))
+        rows = ceil(count / columns)
+        total_height = rows * grid_height + max(0, (rows - 1) * list_widget.spacing())
+        frame_padding = list_widget.frameWidth() * 2
+        list_widget.setFixedHeight(total_height + frame_padding)
+
+    def eventFilter(self, obj, event):  # type: ignore[override]
+        if event.type() == QEvent.Type.Resize and obj in self._text_lists:
+            self._adjust_text_list_height(obj)  # type: ignore[arg-type]
+        return super().eventFilter(obj, event)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -11,10 +11,12 @@ from PyQt6.QtWidgets import (
     QFrame,
     QHBoxLayout,
     QLabel,
+    QListView,
     QMainWindow,
     QListWidget,
     QListWidgetItem,
     QPushButton,
+    QSlider,
     QSplitter,
     QTabWidget,
     QTextEdit,
@@ -39,6 +41,8 @@ class MainWindow(QMainWindow):
         super().__init__()
         self.setWindowTitle("Image Studio IA")
         self.resize(1280, 768)
+        self._image_icon_size = 128
+        self._text_tile_width = 220
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -62,6 +66,7 @@ class MainWindow(QMainWindow):
 
         self.sourcePanel = self._create_source_panel()
         left_layout.addWidget(self.sourcePanel, 1)
+        self._apply_thumbnail_size(self._image_icon_size)
 
         splitter.addWidget(left)
 
@@ -184,15 +189,58 @@ class MainWindow(QMainWindow):
         status.setObjectName("SourceStatus")
         layout.addWidget(status)
 
-        file_list = QListWidget()
-        file_list.setObjectName("SourceFileList")
-        file_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
-        file_list.setIconSize(QSize(112, 112))
-        layout.addWidget(file_list, 1)
+        slider_row = QHBoxLayout()
+        slider_caption = QLabel("Tamanho das miniaturas")
+        slider_row.addWidget(slider_caption)
+        thumbnail_slider = QSlider(Qt.Orientation.Horizontal)
+        thumbnail_slider.setObjectName("SourceThumbnailSlider")
+        thumbnail_slider.setRange(80, 224)
+        thumbnail_slider.setSingleStep(8)
+        thumbnail_slider.setPageStep(16)
+        thumbnail_slider.setValue(self._image_icon_size)
+        thumbnail_slider.valueChanged.connect(self._update_thumbnail_size)
+        slider_row.addWidget(thumbnail_slider, 1)
+        layout.addLayout(slider_row)
+
+        text_title = QLabel("Arquivos de texto")
+        text_title.setObjectName("SourceTextTitle")
+        layout.addWidget(text_title)
+
+        text_list = QListWidget()
+        text_list.setObjectName("SourceTextList")
+        text_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
+        text_list.setViewMode(QListView.ViewMode.IconMode)
+        text_list.setResizeMode(QListView.ResizeMode.Adjust)
+        text_list.setMovement(QListView.Movement.Static)
+        text_list.setWrapping(True)
+        text_list.setSpacing(12)
+        text_list.setWordWrap(True)
+        text_list.setGridSize(QSize(self._text_tile_width, 72))
+        layout.addWidget(text_list)
+
+        image_title = QLabel("Imagens")
+        image_title.setObjectName("SourceImageTitle")
+        layout.addWidget(image_title)
+
+        image_list = QListWidget()
+        image_list.setObjectName("SourceImageList")
+        image_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
+        image_list.setViewMode(QListView.ViewMode.IconMode)
+        image_list.setResizeMode(QListView.ResizeMode.Adjust)
+        image_list.setMovement(QListView.Movement.Static)
+        image_list.setWrapping(True)
+        image_list.setSpacing(16)
+        image_list.setWordWrap(True)
+        image_list.setUniformItemSizes(False)
+        layout.addWidget(image_list, 1)
+
+        frame.thumbnailSlider = thumbnail_slider  # type: ignore[attr-defined]
+        frame.textList = text_list  # type: ignore[attr-defined]
+        frame.imageList = image_list  # type: ignore[attr-defined]
 
         frame.pathLabel = path_label  # type: ignore[attr-defined]
         frame.statusLabel = status  # type: ignore[attr-defined]
-        frame.fileList = file_list  # type: ignore[attr-defined]
+
         return frame
 
     def _create_composer(self) -> QWidget:
@@ -232,27 +280,112 @@ class MainWindow(QMainWindow):
             path_label.setText(str(folder))
 
     def set_source_files(self, files: Iterable[Path]) -> None:
-        file_list: QListWidget | None = getattr(self.sourcePanel, "fileList", None)
-        if file_list is None:
+        image_list: QListWidget | None = getattr(self.sourcePanel, "imageList", None)
+        text_list: QListWidget | None = getattr(self.sourcePanel, "textList", None)
+        status_label: QLabel | None = getattr(self.sourcePanel, "statusLabel", None)
+        if image_list is None or text_list is None:
             return
-        file_list.clear()
-        count = 0
+
+        image_list.clear()
+        text_list.clear()
+
+        image_extensions = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+        text_extensions = {".txt"}
+        image_count = 0
+        text_count = 0
+
+        thumbnail_size = image_list.iconSize()
         for file in files:
+            suffix = file.suffix.lower()
             item = QListWidgetItem(file.name)
             item.setToolTip(str(file))
-            suffix = file.suffix.lower()
-            if suffix in {".png", ".jpg", ".jpeg", ".webp", ".bmp"}:
+            item.setData(Qt.ItemDataRole.UserRole, file.name)
+            item.setTextAlignment(Qt.AlignmentFlag.AlignHCenter)
+            if suffix in image_extensions:
                 pixmap = QPixmap(str(file))
                 if not pixmap.isNull():
                     thumbnail = pixmap.scaled(
-                        file_list.iconSize(),
+                        thumbnail_size,
                         Qt.AspectRatioMode.KeepAspectRatio,
                         Qt.TransformationMode.SmoothTransformation,
                     )
                     item.setIcon(QIcon(thumbnail))
-            file_list.addItem(item)
-            count += 1
-        file_list.setEnabled(count > 0)
+                image_list.addItem(item)
+                image_count += 1
+            elif suffix in text_extensions:
+                text_list.addItem(item)
+                text_count += 1
+
+        image_list.setEnabled(image_count > 0)
+        text_list.setEnabled(text_count > 0)
+
+        self._refresh_image_captions()
+        self._refresh_text_captions()
+
+        if status_label is not None:
+            if image_count == 0 and text_count == 0:
+                status_label.setText("Nenhum arquivo compatível encontrado.")
+            else:
+                parts: list[str] = []
+                if image_count:
+                    parts.append(
+                        f"{image_count} imagem{'s' if image_count != 1 else ''} encontrada"
+                    )
+                if text_count:
+                    parts.append(
+                        f"{text_count} arquivo{'s' if text_count != 1 else ''} de texto"
+                    )
+                status_label.setText(" • ".join(parts))
+
+    def _update_thumbnail_size(self, value: int) -> None:
+        self._apply_thumbnail_size(value)
+        self._refresh_image_captions()
+
+    def _apply_thumbnail_size(self, size: int) -> None:
+        self._image_icon_size = size
+        icon_extent = QSize(size, size)
+        image_list: QListWidget | None = getattr(self.sourcePanel, "imageList", None)
+        slider: QSlider | None = getattr(self.sourcePanel, "thumbnailSlider", None)
+        if image_list is None:
+            if slider is not None and slider.value() != size:
+                slider.blockSignals(True)
+                slider.setValue(size)
+                slider.blockSignals(False)
+            return
+        image_list.setIconSize(icon_extent)
+        grid_width = size + 64
+        grid_height = size + 72
+        image_list.setGridSize(QSize(grid_width, grid_height))
+        if slider is not None and slider.value() != size:
+            slider.blockSignals(True)
+            slider.setValue(size)
+            slider.blockSignals(False)
+
+    def _refresh_image_captions(self) -> None:
+        image_list: QListWidget | None = getattr(self.sourcePanel, "imageList", None)
+        if image_list is None:
+            return
+        available_width = image_list.gridSize().width() - 24
+        self._refresh_list_labels(image_list, available_width)
+
+    def _refresh_text_captions(self) -> None:
+        text_list: QListWidget | None = getattr(self.sourcePanel, "textList", None)
+        if text_list is None:
+            return
+        available_width = text_list.gridSize().width() - 16
+        self._refresh_list_labels(text_list, available_width)
+
+    def _refresh_list_labels(self, list_widget: QListWidget, width: int) -> None:
+        if width <= 0:
+            return
+        metrics = list_widget.fontMetrics()
+        for index in range(list_widget.count()):
+            item = list_widget.item(index)
+            original = item.data(Qt.ItemDataRole.UserRole)
+            if original is None:
+                original = item.text()
+            elided = metrics.elidedText(str(original), Qt.TextElideMode.ElideMiddle, width)
+            item.setText(elided)
 
     def update_source_status(self, message: str) -> None:
         status_label = getattr(self.sourcePanel, "statusLabel", None)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
+from typing import Callable, Iterable
 
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
@@ -11,6 +11,8 @@ from PyQt6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QMainWindow,
+    QListWidget,
+    QListWidgetItem,
     QPushButton,
     QSplitter,
     QTabWidget,
@@ -20,8 +22,6 @@ from PyQt6.QtWidgets import (
 )
 
 from .config_panel import ConfigPanel
-from .sidebar import Sidebar
-from .tabs.gallery_tab import GalleryTab
 from .tabs.home_tab import HomeTab
 from .tabs.settings_tab import SettingsTab
 
@@ -31,6 +31,7 @@ class MainWindow(QMainWindow):
 
     promptSubmitted = pyqtSignal(str)
     browseFolderRequested = pyqtSignal()
+    outputBrowseRequested = pyqtSignal()
     configRequested = pyqtSignal()
 
     def __init__(self) -> None:
@@ -58,13 +59,8 @@ class MainWindow(QMainWindow):
         left_layout.setContentsMargins(16, 16, 12, 16)
         left_layout.setSpacing(12)
 
-        self.leftViewer = self._create_viewer("Pasta selecionada")
-        left_layout.addWidget(self.leftViewer)
-
-        self.sidebar = Sidebar()
-        self.sidebar.folderSelected.connect(self._on_folder_selected)
-        self.sidebar.browseRequested.connect(self.browseFolderRequested.emit)
-        left_layout.addWidget(self.sidebar, 1)
+        self.sourcePanel = self._create_source_panel()
+        left_layout.addWidget(self.sourcePanel, 1)
 
         splitter.addWidget(left)
 
@@ -73,7 +69,12 @@ class MainWindow(QMainWindow):
         right_layout.setContentsMargins(12, 16, 16, 16)
         right_layout.setSpacing(12)
 
-        self.rightViewer = self._create_viewer("Saída das imagens geradas")
+        self.rightViewer = self._create_viewer(
+            "Saída das imagens geradas",
+            browse_text="Selecionar pasta de saída…",
+            browse_slot=self.outputBrowseRequested.emit,
+            placeholder_text="Selecione uma pasta para salvar suas imagens geradas",
+        )
         right_layout.addWidget(self.rightViewer)
 
         self.configPanel = ConfigPanel()
@@ -81,10 +82,8 @@ class MainWindow(QMainWindow):
 
         self.tabs = QTabWidget()
         self.homeTab = HomeTab()
-        self.galleryTab = GalleryTab()
         self.settingsTab = SettingsTab()
         self.tabs.addTab(self.homeTab, "Início")
-        self.tabs.addTab(self.galleryTab, "Galeria")
         self.tabs.addTab(self.settingsTab, "Configurações")
         right_layout.addWidget(self.tabs, 1)
 
@@ -94,6 +93,11 @@ class MainWindow(QMainWindow):
         splitter.addWidget(right)
         splitter.setStretchFactor(0, 2)
         splitter.setStretchFactor(1, 3)
+
+        right_layout.setStretch(0, 3)
+        right_layout.setStretch(1, 1)
+        right_layout.setStretch(2, 2)
+        right_layout.setStretch(3, 1)
 
     def _create_topbar(self) -> QWidget:
         frame = QFrame()
@@ -115,7 +119,14 @@ class MainWindow(QMainWindow):
         layout.addWidget(self.configButton)
         return frame
 
-    def _create_viewer(self, title: str) -> QWidget:
+    def _create_viewer(
+        self,
+        title: str,
+        *,
+        browse_text: str | None = None,
+        browse_slot: Callable[[], None] | None = None,
+        placeholder_text: str = "Selecione uma pasta para visualizar suas imagens",
+    ) -> QWidget:
         frame = QFrame()
         frame.setObjectName("Viewer")
         layout = QVBoxLayout(frame)
@@ -126,7 +137,17 @@ class MainWindow(QMainWindow):
         caption.setObjectName("ViewerTitle")
         layout.addWidget(caption)
 
-        placeholder = QLabel("Selecione uma pasta para visualizar suas imagens")
+        if browse_text and browse_slot:
+            browse_button = QPushButton(browse_text)
+            browse_button.clicked.connect(browse_slot)
+            layout.addWidget(browse_button)
+
+        path_label = QLabel("Nenhuma pasta selecionada.")
+        path_label.setObjectName("ViewerPath")
+        path_label.setWordWrap(True)
+        layout.addWidget(path_label)
+
+        placeholder = QLabel(placeholder_text)
         placeholder.setWordWrap(True)
         placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
         placeholder.setObjectName("ViewerPlaceholder")
@@ -134,6 +155,42 @@ class MainWindow(QMainWindow):
 
         frame.captionLabel = caption  # type: ignore[attr-defined]
         frame.placeholderLabel = placeholder  # type: ignore[attr-defined]
+        frame.pathLabel = path_label  # type: ignore[attr-defined]
+        return frame
+
+    def _create_source_panel(self) -> QWidget:
+        frame = QFrame()
+        frame.setObjectName("SourcePanel")
+        layout = QVBoxLayout(frame)
+        layout.setContentsMargins(12, 12, 12, 12)
+        layout.setSpacing(10)
+
+        title = QLabel("Arquivos da pasta selecionada")
+        title.setObjectName("SourceTitle")
+        layout.addWidget(title)
+
+        browse_button = QPushButton("Escolher pasta…")
+        browse_button.clicked.connect(self.browseFolderRequested.emit)
+        layout.addWidget(browse_button)
+
+        path_label = QLabel("Nenhuma pasta selecionada.")
+        path_label.setWordWrap(True)
+        path_label.setObjectName("SourcePath")
+        layout.addWidget(path_label)
+
+        status = QLabel("Os arquivos compatíveis serão exibidos aqui.")
+        status.setWordWrap(True)
+        status.setObjectName("SourceStatus")
+        layout.addWidget(status)
+
+        file_list = QListWidget()
+        file_list.setObjectName("SourceFileList")
+        file_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
+        layout.addWidget(file_list, 1)
+
+        frame.pathLabel = path_label  # type: ignore[attr-defined]
+        frame.statusLabel = status  # type: ignore[attr-defined]
+        frame.fileList = file_list  # type: ignore[attr-defined]
         return frame
 
     def _create_composer(self) -> QWidget:
@@ -163,22 +220,32 @@ class MainWindow(QMainWindow):
         if text:
             self.promptSubmitted.emit(text)
 
-    def _on_folder_selected(self, folder: Path) -> None:
-        self.set_path_label(folder)
-
     # Public helpers -----------------------------------------------------
     def set_path_label(self, path: Path) -> None:
         self.pathLabel.setText(f"Pasta: {path}")
 
-    def set_directories(self, directories: Iterable[Path]) -> None:
-        self.sidebar.set_directories(directories)
+    def set_source_folder(self, folder: Path) -> None:
+        path_label = getattr(self.sourcePanel, "pathLabel", None)
+        if path_label is not None:
+            path_label.setText(str(folder))
 
-    def select_directory(self, directory: Path) -> None:
-        self.sidebar.select_folder(directory)
-        self.set_path_label(directory)
+    def set_source_files(self, files: Iterable[Path]) -> None:
+        file_list: QListWidget | None = getattr(self.sourcePanel, "fileList", None)
+        if file_list is None:
+            return
+        file_list.clear()
+        count = 0
+        for file in files:
+            item = QListWidgetItem(file.name)
+            item.setToolTip(str(file))
+            file_list.addItem(item)
+            count += 1
+        file_list.setEnabled(count > 0)
 
-    def set_gallery_images(self, images: Iterable[Path]) -> None:
-        self.galleryTab.set_images(images)
+    def update_source_status(self, message: str) -> None:
+        status_label = getattr(self.sourcePanel, "statusLabel", None)
+        if status_label is not None:
+            status_label.setText(message)
 
     def apply_config(self, namespace: str, data: dict[str, object]) -> None:
         if namespace == "image":
@@ -192,12 +259,18 @@ class MainWindow(QMainWindow):
             caption.setText(title)
         if message and placeholder is not None:
             placeholder.setText(message)
-
-    def update_left_viewer(self, title: str, message: str) -> None:
-        self.update_viewer(self.leftViewer, title=title, message=message)
-
     def update_right_viewer(self, title: str, message: str) -> None:
         self.update_viewer(self.rightViewer, title=title, message=message)
+
+    def set_output_folder(self, folder: Path) -> None:
+        path_label = getattr(self.rightViewer, "pathLabel", None)
+        if path_label is not None:
+            path_label.setText(str(folder))
+
+    def clear_output_folder(self) -> None:
+        path_label = getattr(self.rightViewer, "pathLabel", None)
+        if path_label is not None:
+            path_label.setText("Nenhuma pasta selecionada.")
 
     def prompt_text(self) -> str:
         return self.promptEdit.toPlainText()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -24,7 +24,6 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from .config_panel import ConfigPanel
 from .tabs.home_tab import HomeTab
 from .tabs.settings_tab import SettingsTab
 
@@ -36,6 +35,9 @@ class MainWindow(QMainWindow):
     browseFolderRequested = pyqtSignal()
     outputBrowseRequested = pyqtSignal()
     configRequested = pyqtSignal()
+
+    IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+    TEXT_EXTENSIONS = {".txt"}
 
     def __init__(self) -> None:
         super().__init__()
@@ -64,28 +66,21 @@ class MainWindow(QMainWindow):
         left_layout = QVBoxLayout(left)
         left_layout.setContentsMargins(16, 16, 12, 16)
         left_layout.setSpacing(12)
-
-        self.sourcePanel = self._create_source_panel()
+        self.sourcePanel = self._create_file_panel(
+            title="Arquivos da pasta selecionada",
+            browse_text="Escolher pasta…",
+            browse_slot=self.browseFolderRequested.emit,
+            status_text="Os arquivos compatíveis serão exibidos aqui.",
+            object_name="SourcePanel",
+            enable_selection=True,
+        )
         left_layout.addWidget(self.sourcePanel, 1)
-        self._apply_thumbnail_size(self._image_icon_size)
-
         splitter.addWidget(left)
 
-        right = QWidget()
-        right_layout = QVBoxLayout(right)
-        right_layout.setContentsMargins(12, 16, 16, 16)
-        right_layout.setSpacing(12)
-
-        self.rightViewer = self._create_viewer(
-            "Saída das imagens geradas",
-            browse_text="Selecionar pasta de saída…",
-            browse_slot=self.outputBrowseRequested.emit,
-            placeholder_text="Selecione uma pasta para salvar suas imagens geradas",
-        )
-        right_layout.addWidget(self.rightViewer)
-
-        self.configPanel = ConfigPanel()
-        right_layout.addWidget(self.configPanel)
+        center = QWidget()
+        center_layout = QVBoxLayout(center)
+        center_layout.setContentsMargins(12, 16, 12, 16)
+        center_layout.setSpacing(12)
 
         self.tabs = QTabWidget()
         self.homeTab = HomeTab()
@@ -94,19 +89,36 @@ class MainWindow(QMainWindow):
         self.selectedTab = self._create_selected_tab()
         self.tabs.addTab(self.selectedTab, "Selecionados")
         self.tabs.addTab(self.settingsTab, "Configurações")
-        right_layout.addWidget(self.tabs, 1)
+        center_layout.addWidget(self.tabs, 1)
 
         composer = self._create_composer()
-        right_layout.addWidget(composer)
+        center_layout.addWidget(composer)
 
+        center_layout.setStretch(0, 3)
+        center_layout.setStretch(1, 2)
+
+        splitter.addWidget(center)
+
+        right = QWidget()
+        right_layout = QVBoxLayout(right)
+        right_layout.setContentsMargins(12, 16, 16, 16)
+        right_layout.setSpacing(12)
+        self.outputPanel = self._create_file_panel(
+            title="Arquivos da pasta de destino",
+            browse_text="Selecionar pasta de saída…",
+            browse_slot=self.outputBrowseRequested.emit,
+            status_text="Os arquivos salvos serão exibidos aqui.",
+            object_name="OutputPanel",
+            enable_selection=False,
+        )
+        right_layout.addWidget(self.outputPanel, 1)
         splitter.addWidget(right)
+
         splitter.setStretchFactor(0, 2)
         splitter.setStretchFactor(1, 3)
+        splitter.setStretchFactor(2, 2)
 
-        right_layout.setStretch(0, 3)
-        right_layout.setStretch(1, 1)
-        right_layout.setStretch(2, 2)
-        right_layout.setStretch(3, 1)
+        self._apply_thumbnail_size(self._image_icon_size)
 
     def _create_topbar(self) -> QWidget:
         frame = QFrame()
@@ -128,75 +140,45 @@ class MainWindow(QMainWindow):
         layout.addWidget(self.configButton)
         return frame
 
-    def _create_viewer(
+    def _create_file_panel(
         self,
-        title: str,
         *,
-        browse_text: str | None = None,
-        browse_slot: Callable[[], None] | None = None,
-        placeholder_text: str = "Selecione uma pasta para visualizar suas imagens",
+        title: str,
+        browse_text: str,
+        browse_slot: Callable[[], None],
+        status_text: str,
+        object_name: str,
+        enable_selection: bool,
     ) -> QWidget:
         frame = QFrame()
-        frame.setObjectName("Viewer")
-        layout = QVBoxLayout(frame)
-        layout.setContentsMargins(12, 12, 12, 12)
-        layout.setSpacing(8)
-
-        caption = QLabel(title)
-        caption.setObjectName("ViewerTitle")
-        layout.addWidget(caption)
-
-        if browse_text and browse_slot:
-            browse_button = QPushButton(browse_text)
-            browse_button.clicked.connect(browse_slot)
-            layout.addWidget(browse_button)
-
-        path_label = QLabel("Nenhuma pasta selecionada.")
-        path_label.setObjectName("ViewerPath")
-        path_label.setWordWrap(True)
-        layout.addWidget(path_label)
-
-        placeholder = QLabel(placeholder_text)
-        placeholder.setWordWrap(True)
-        placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        placeholder.setObjectName("ViewerPlaceholder")
-        layout.addWidget(placeholder, 1)
-
-        frame.captionLabel = caption  # type: ignore[attr-defined]
-        frame.placeholderLabel = placeholder  # type: ignore[attr-defined]
-        frame.pathLabel = path_label  # type: ignore[attr-defined]
-        return frame
-
-    def _create_source_panel(self) -> QWidget:
-        frame = QFrame()
-        frame.setObjectName("SourcePanel")
+        frame.setObjectName(object_name)
         layout = QVBoxLayout(frame)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(10)
 
-        title = QLabel("Arquivos da pasta selecionada")
-        title.setObjectName("SourceTitle")
-        layout.addWidget(title)
+        title_label = QLabel(title)
+        title_label.setObjectName(f"{object_name}Title")
+        layout.addWidget(title_label)
 
-        browse_button = QPushButton("Escolher pasta…")
-        browse_button.clicked.connect(self.browseFolderRequested.emit)
+        browse_button = QPushButton(browse_text)
+        browse_button.clicked.connect(browse_slot)
         layout.addWidget(browse_button)
 
         path_label = QLabel("Nenhuma pasta selecionada.")
         path_label.setWordWrap(True)
-        path_label.setObjectName("SourcePath")
+        path_label.setObjectName(f"{object_name}Path")
         layout.addWidget(path_label)
 
-        status = QLabel("Os arquivos compatíveis serão exibidos aqui.")
+        status = QLabel(status_text)
         status.setWordWrap(True)
-        status.setObjectName("SourceStatus")
+        status.setObjectName(f"{object_name}Status")
         layout.addWidget(status)
 
         slider_row = QHBoxLayout()
         slider_caption = QLabel("Tamanho das miniaturas")
         slider_row.addWidget(slider_caption)
         thumbnail_slider = QSlider(Qt.Orientation.Horizontal)
-        thumbnail_slider.setObjectName("SourceThumbnailSlider")
+        thumbnail_slider.setObjectName(f"{object_name}ThumbnailSlider")
         thumbnail_slider.setRange(80, 224)
         thumbnail_slider.setSingleStep(8)
         thumbnail_slider.setPageStep(16)
@@ -206,7 +188,7 @@ class MainWindow(QMainWindow):
         layout.addLayout(slider_row)
 
         text_list = QListWidget()
-        text_list.setObjectName("SourceTextList")
+        text_list.setObjectName(f"{object_name}TextList")
         text_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
         text_list.setViewMode(QListView.ViewMode.IconMode)
         text_list.setResizeMode(QListView.ResizeMode.Adjust)
@@ -218,7 +200,7 @@ class MainWindow(QMainWindow):
         layout.addWidget(text_list)
 
         image_list = QListWidget()
-        image_list.setObjectName("SourceImageList")
+        image_list.setObjectName(f"{object_name}ImageList")
         image_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
         image_list.setViewMode(QListView.ViewMode.IconMode)
         image_list.setResizeMode(QListView.ResizeMode.Adjust)
@@ -232,12 +214,12 @@ class MainWindow(QMainWindow):
         frame.thumbnailSlider = thumbnail_slider  # type: ignore[attr-defined]
         frame.textList = text_list  # type: ignore[attr-defined]
         frame.imageList = image_list  # type: ignore[attr-defined]
-
-        text_list.itemDoubleClicked.connect(self._handle_source_double_click)
-        image_list.itemDoubleClicked.connect(self._handle_source_double_click)
-
         frame.pathLabel = path_label  # type: ignore[attr-defined]
         frame.statusLabel = status  # type: ignore[attr-defined]
+
+        if enable_selection:
+            text_list.itemDoubleClicked.connect(self._handle_source_double_click)
+            image_list.itemDoubleClicked.connect(self._handle_source_double_click)
 
         return frame
 
@@ -312,49 +294,11 @@ class MainWindow(QMainWindow):
             path_label.setText(str(folder))
 
     def set_source_files(self, files: Iterable[Path]) -> None:
-        image_list: QListWidget | None = getattr(self.sourcePanel, "imageList", None)
-        text_list: QListWidget | None = getattr(self.sourcePanel, "textList", None)
         status_label: QLabel | None = getattr(self.sourcePanel, "statusLabel", None)
-        if image_list is None or text_list is None:
-            return
+        image_count, text_count = self._populate_panel_files(self.sourcePanel, files)
 
-        image_list.clear()
-        text_list.clear()
-
-        image_extensions = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
-        text_extensions = {".txt"}
-        image_count = 0
-        text_count = 0
-
-        thumbnail_size = image_list.iconSize()
-        for file in files:
-            suffix = file.suffix.lower()
-            full_path = str(file)
-            item = QListWidgetItem(file.name)
-            item.setToolTip(full_path)
-            item.setData(Qt.ItemDataRole.UserRole, file.name)
-            item.setData(Qt.ItemDataRole.UserRole + 1, full_path)
-            item.setTextAlignment(Qt.AlignmentFlag.AlignHCenter)
-            if suffix in image_extensions:
-                pixmap = QPixmap(str(file))
-                if not pixmap.isNull():
-                    thumbnail = pixmap.scaled(
-                        thumbnail_size,
-                        Qt.AspectRatioMode.KeepAspectRatio,
-                        Qt.TransformationMode.SmoothTransformation,
-                    )
-                    item.setIcon(QIcon(thumbnail))
-                image_list.addItem(item)
-                image_count += 1
-            elif suffix in text_extensions:
-                text_list.addItem(item)
-                text_count += 1
-
-        image_list.setEnabled(image_count > 0)
-        text_list.setEnabled(text_count > 0)
-
-        self._refresh_image_captions()
-        self._refresh_text_captions()
+        self._refresh_image_captions(self.sourcePanel)
+        self._refresh_text_captions(self.sourcePanel)
         self._refresh_selected_captions()
 
         if status_label is not None:
@@ -372,48 +316,129 @@ class MainWindow(QMainWindow):
                     )
                 status_label.setText(" • ".join(parts))
 
+    def set_output_files(self, files: Iterable[Path]) -> None:
+        status_label: QLabel | None = getattr(self.outputPanel, "statusLabel", None)
+        image_count, text_count = self._populate_panel_files(self.outputPanel, files)
+
+        self._refresh_image_captions(self.outputPanel)
+        self._refresh_text_captions(self.outputPanel)
+
+        if status_label is not None:
+            if image_count == 0 and text_count == 0:
+                status_label.setText("Nenhum arquivo encontrado na pasta de destino.")
+            else:
+                parts: list[str] = []
+                if image_count:
+                    parts.append(
+                        f"{image_count} imagem{'s' if image_count != 1 else ''} disponível"
+                    )
+                if text_count:
+                    parts.append(
+                        f"{text_count} arquivo{'s' if text_count != 1 else ''} de texto"
+                    )
+                status_label.setText(" • ".join(parts))
+
+    def _populate_panel_files(
+        self, panel: QWidget | None, files: Iterable[Path]
+    ) -> tuple[int, int]:
+        image_list: QListWidget | None = getattr(panel, "imageList", None) if panel else None
+        text_list: QListWidget | None = getattr(panel, "textList", None) if panel else None
+        if image_list is None or text_list is None:
+            return (0, 0)
+
+        image_list.clear()
+        text_list.clear()
+
+        thumbnail_size = image_list.iconSize()
+        image_count = 0
+        text_count = 0
+
+        for file in files:
+            suffix = file.suffix.lower()
+            full_path = str(file)
+            item = QListWidgetItem(file.name)
+            item.setToolTip(full_path)
+            item.setData(Qt.ItemDataRole.UserRole, file.name)
+            item.setData(Qt.ItemDataRole.UserRole + 1, full_path)
+            item.setTextAlignment(Qt.AlignmentFlag.AlignHCenter)
+            if suffix in self.IMAGE_EXTENSIONS:
+                pixmap = QPixmap(full_path)
+                if not pixmap.isNull():
+                    thumbnail = pixmap.scaled(
+                        thumbnail_size,
+                        Qt.AspectRatioMode.KeepAspectRatio,
+                        Qt.TransformationMode.SmoothTransformation,
+                    )
+                    item.setIcon(QIcon(thumbnail))
+                image_list.addItem(item)
+                image_count += 1
+            elif suffix in self.TEXT_EXTENSIONS:
+                text_list.addItem(item)
+                text_count += 1
+
+        image_list.setEnabled(image_count > 0)
+        text_list.setEnabled(text_count > 0)
+        return image_count, text_count
+
     def _update_thumbnail_size(self, value: int) -> None:
         self._apply_thumbnail_size(value)
-        self._refresh_image_captions()
+        self._refresh_image_captions(self.sourcePanel)
+        self._refresh_image_captions(self.outputPanel)
         self._refresh_selected_captions()
 
     def _apply_thumbnail_size(self, size: int) -> None:
         self._image_icon_size = size
         icon_extent = QSize(size, size)
-        image_list: QListWidget | None = getattr(self.sourcePanel, "imageList", None)
-        slider: QSlider | None = getattr(self.sourcePanel, "thumbnailSlider", None)
-        selected_tab = getattr(self, "selectedTab", None)
-        selected_list: QListWidget | None = (
-            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
-        )
-        if image_list is None:
+        grid_width = size + 40
+        grid_height = size + 56
+
+        panels = [getattr(self, "sourcePanel", None), getattr(self, "outputPanel", None)]
+        for panel in panels:
+            if panel is None:
+                continue
+            image_list: QListWidget | None = getattr(panel, "imageList", None)
+            slider: QSlider | None = getattr(panel, "thumbnailSlider", None)
+            if image_list is not None:
+                image_list.setIconSize(icon_extent)
+                image_list.setGridSize(QSize(grid_width, grid_height))
             if slider is not None and slider.value() != size:
                 slider.blockSignals(True)
                 slider.setValue(size)
                 slider.blockSignals(False)
-            return
-        image_list.setIconSize(icon_extent)
-        grid_width = size + 40
-        grid_height = size + 56
-        image_list.setGridSize(QSize(grid_width, grid_height))
+
+        selected_tab = getattr(self, "selectedTab", None)
+        selected_list: QListWidget | None = (
+            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
+        )
         if selected_list is not None:
             selected_list.setIconSize(icon_extent)
             selected_list.setGridSize(QSize(grid_width, grid_height))
-            selected_list.setSpacing(image_list.spacing())
-        if slider is not None and slider.value() != size:
-            slider.blockSignals(True)
-            slider.setValue(size)
-            slider.blockSignals(False)
+            source_panel = getattr(self, "sourcePanel", None)
+            spacing_reference = None
+            if source_panel is not None:
+                source_images: QListWidget | None = getattr(source_panel, "imageList", None)
+                if source_images is not None:
+                    spacing_reference = source_images.spacing()
+            if spacing_reference is not None:
+                selected_list.setSpacing(spacing_reference)
 
-    def _refresh_image_captions(self) -> None:
-        image_list: QListWidget | None = getattr(self.sourcePanel, "imageList", None)
+    def _refresh_image_captions(self, panel: QWidget | None = None) -> None:
+        image_list: QListWidget | None = None
+        if panel is not None:
+            image_list = getattr(panel, "imageList", None)
+        elif hasattr(self, "sourcePanel"):
+            image_list = getattr(self.sourcePanel, "imageList", None)
         if image_list is None:
             return
         available_width = image_list.gridSize().width() - 24
         self._refresh_list_labels(image_list, available_width)
 
-    def _refresh_text_captions(self) -> None:
-        text_list: QListWidget | None = getattr(self.sourcePanel, "textList", None)
+    def _refresh_text_captions(self, panel: QWidget | None = None) -> None:
+        text_list: QListWidget | None = None
+        if panel is not None:
+            text_list = getattr(panel, "textList", None)
+        elif hasattr(self, "sourcePanel"):
+            text_list = getattr(self.sourcePanel, "textList", None)
         if text_list is None:
             return
         available_width = text_list.gridSize().width() - 12
@@ -516,28 +541,22 @@ class MainWindow(QMainWindow):
 
     def apply_config(self, namespace: str, data: dict[str, object]) -> None:
         if namespace == "image":
-            self.configPanel.apply_config(data)
             self.settingsTab.apply_config(namespace, data)
 
-    def update_viewer(self, viewer: QWidget, *, title: str | None = None, message: str | None = None) -> None:
-        caption = getattr(viewer, "captionLabel", None)
-        placeholder = getattr(viewer, "placeholderLabel", None)
-        if title and caption is not None:
-            caption.setText(title)
-        if message and placeholder is not None:
-            placeholder.setText(message)
-    def update_right_viewer(self, title: str, message: str) -> None:
-        self.update_viewer(self.rightViewer, title=title, message=message)
-
     def set_output_folder(self, folder: Path) -> None:
-        path_label = getattr(self.rightViewer, "pathLabel", None)
+        path_label = getattr(self.outputPanel, "pathLabel", None)
         if path_label is not None:
             path_label.setText(str(folder))
 
     def clear_output_folder(self) -> None:
-        path_label = getattr(self.rightViewer, "pathLabel", None)
+        path_label = getattr(self.outputPanel, "pathLabel", None)
         if path_label is not None:
             path_label.setText("Nenhuma pasta selecionada.")
+
+    def update_output_status(self, message: str) -> None:
+        status_label = getattr(self.outputPanel, "statusLabel", None)
+        if status_label is not None:
+            status_label.setText(message)
 
     def prompt_text(self) -> str:
         return self.promptEdit.toPlainText()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -43,6 +43,7 @@ class MainWindow(QMainWindow):
         self.resize(1280, 768)
         self._image_icon_size = 128
         self._text_tile_width = 220
+        self._selected_paths: set[str] = set()
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -90,6 +91,8 @@ class MainWindow(QMainWindow):
         self.homeTab = HomeTab()
         self.settingsTab = SettingsTab()
         self.tabs.addTab(self.homeTab, "Início")
+        self.selectedTab = self._create_selected_tab()
+        self.tabs.addTab(self.selectedTab, "Selecionados")
         self.tabs.addTab(self.settingsTab, "Configurações")
         right_layout.addWidget(self.tabs, 1)
 
@@ -202,10 +205,6 @@ class MainWindow(QMainWindow):
         slider_row.addWidget(thumbnail_slider, 1)
         layout.addLayout(slider_row)
 
-        text_title = QLabel("Arquivos de texto")
-        text_title.setObjectName("SourceTextTitle")
-        layout.addWidget(text_title)
-
         text_list = QListWidget()
         text_list.setObjectName("SourceTextList")
         text_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
@@ -213,14 +212,10 @@ class MainWindow(QMainWindow):
         text_list.setResizeMode(QListView.ResizeMode.Adjust)
         text_list.setMovement(QListView.Movement.Static)
         text_list.setWrapping(True)
-        text_list.setSpacing(12)
+        text_list.setSpacing(4)
         text_list.setWordWrap(True)
-        text_list.setGridSize(QSize(self._text_tile_width, 72))
+        text_list.setGridSize(QSize(self._text_tile_width, 52))
         layout.addWidget(text_list)
-
-        image_title = QLabel("Imagens")
-        image_title.setObjectName("SourceImageTitle")
-        layout.addWidget(image_title)
 
         image_list = QListWidget()
         image_list.setObjectName("SourceImageList")
@@ -229,7 +224,7 @@ class MainWindow(QMainWindow):
         image_list.setResizeMode(QListView.ResizeMode.Adjust)
         image_list.setMovement(QListView.Movement.Static)
         image_list.setWrapping(True)
-        image_list.setSpacing(16)
+        image_list.setSpacing(8)
         image_list.setWordWrap(True)
         image_list.setUniformItemSizes(False)
         layout.addWidget(image_list, 1)
@@ -238,10 +233,47 @@ class MainWindow(QMainWindow):
         frame.textList = text_list  # type: ignore[attr-defined]
         frame.imageList = image_list  # type: ignore[attr-defined]
 
+        text_list.itemDoubleClicked.connect(self._handle_source_double_click)
+        image_list.itemDoubleClicked.connect(self._handle_source_double_click)
+
         frame.pathLabel = path_label  # type: ignore[attr-defined]
         frame.statusLabel = status  # type: ignore[attr-defined]
 
         return frame
+
+    def _create_selected_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        description = QLabel(
+            "Arquivos selecionados a partir da pasta de origem. Dê um clique duplo para removê-los."
+        )
+        description.setWordWrap(True)
+        layout.addWidget(description)
+
+        list_widget = QListWidget()
+        list_widget.setObjectName("SelectedFileList")
+        list_widget.setViewMode(QListView.ViewMode.IconMode)
+        list_widget.setResizeMode(QListView.ResizeMode.Adjust)
+        list_widget.setMovement(QListView.Movement.Static)
+        list_widget.setWrapping(True)
+        list_widget.setSpacing(8)
+        list_widget.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
+        list_widget.setIconSize(QSize(self._image_icon_size, self._image_icon_size))
+        list_widget.setGridSize(QSize(self._image_icon_size + 40, self._image_icon_size + 56))
+        layout.addWidget(list_widget, 1)
+
+        remove_button = QPushButton("Remover selecionados")
+        remove_button.clicked.connect(self._remove_selected_items)
+        layout.addWidget(remove_button)
+
+        list_widget.itemDoubleClicked.connect(self._remove_single_selected_item)
+
+        widget.listWidget = list_widget  # type: ignore[attr-defined]
+        widget.removeButton = remove_button  # type: ignore[attr-defined]
+        return widget
 
     def _create_composer(self) -> QWidget:
         frame = QFrame()
@@ -297,9 +329,11 @@ class MainWindow(QMainWindow):
         thumbnail_size = image_list.iconSize()
         for file in files:
             suffix = file.suffix.lower()
+            full_path = str(file)
             item = QListWidgetItem(file.name)
-            item.setToolTip(str(file))
+            item.setToolTip(full_path)
             item.setData(Qt.ItemDataRole.UserRole, file.name)
+            item.setData(Qt.ItemDataRole.UserRole + 1, full_path)
             item.setTextAlignment(Qt.AlignmentFlag.AlignHCenter)
             if suffix in image_extensions:
                 pixmap = QPixmap(str(file))
@@ -321,6 +355,7 @@ class MainWindow(QMainWindow):
 
         self._refresh_image_captions()
         self._refresh_text_captions()
+        self._refresh_selected_captions()
 
         if status_label is not None:
             if image_count == 0 and text_count == 0:
@@ -340,12 +375,17 @@ class MainWindow(QMainWindow):
     def _update_thumbnail_size(self, value: int) -> None:
         self._apply_thumbnail_size(value)
         self._refresh_image_captions()
+        self._refresh_selected_captions()
 
     def _apply_thumbnail_size(self, size: int) -> None:
         self._image_icon_size = size
         icon_extent = QSize(size, size)
         image_list: QListWidget | None = getattr(self.sourcePanel, "imageList", None)
         slider: QSlider | None = getattr(self.sourcePanel, "thumbnailSlider", None)
+        selected_tab = getattr(self, "selectedTab", None)
+        selected_list: QListWidget | None = (
+            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
+        )
         if image_list is None:
             if slider is not None and slider.value() != size:
                 slider.blockSignals(True)
@@ -353,9 +393,13 @@ class MainWindow(QMainWindow):
                 slider.blockSignals(False)
             return
         image_list.setIconSize(icon_extent)
-        grid_width = size + 64
-        grid_height = size + 72
+        grid_width = size + 40
+        grid_height = size + 56
         image_list.setGridSize(QSize(grid_width, grid_height))
+        if selected_list is not None:
+            selected_list.setIconSize(icon_extent)
+            selected_list.setGridSize(QSize(grid_width, grid_height))
+            selected_list.setSpacing(image_list.spacing())
         if slider is not None and slider.value() != size:
             slider.blockSignals(True)
             slider.setValue(size)
@@ -372,8 +416,18 @@ class MainWindow(QMainWindow):
         text_list: QListWidget | None = getattr(self.sourcePanel, "textList", None)
         if text_list is None:
             return
-        available_width = text_list.gridSize().width() - 16
+        available_width = text_list.gridSize().width() - 12
         self._refresh_list_labels(text_list, available_width)
+
+    def _refresh_selected_captions(self) -> None:
+        selected_tab = getattr(self, "selectedTab", None)
+        selected_list: QListWidget | None = (
+            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
+        )
+        if selected_list is None:
+            return
+        available_width = selected_list.gridSize().width() - 24
+        self._refresh_list_labels(selected_list, available_width)
 
     def _refresh_list_labels(self, list_widget: QListWidget, width: int) -> None:
         if width <= 0:
@@ -386,6 +440,74 @@ class MainWindow(QMainWindow):
                 original = item.text()
             elided = metrics.elidedText(str(original), Qt.TextElideMode.ElideMiddle, width)
             item.setText(elided)
+
+    def _handle_source_double_click(self, item: QListWidgetItem) -> None:
+        path_data = item.data(Qt.ItemDataRole.UserRole + 1)
+        if not path_data:
+            return
+        self._add_selected_file(Path(str(path_data)))
+
+    def _add_selected_file(self, path: Path) -> None:
+        selected_tab = getattr(self, "selectedTab", None)
+        selected_list: QListWidget | None = (
+            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
+        )
+        if selected_list is None:
+            return
+        path_str = str(path)
+        if path_str in self._selected_paths:
+            self.tabs.setCurrentWidget(self.selectedTab)
+            return
+
+        item = QListWidgetItem(path.name)
+        item.setData(Qt.ItemDataRole.UserRole, path.name)
+        item.setData(Qt.ItemDataRole.UserRole + 1, path_str)
+        item.setToolTip(path_str)
+        item.setTextAlignment(Qt.AlignmentFlag.AlignHCenter)
+
+        image_extensions = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+        if path.suffix.lower() in image_extensions:
+            pixmap = QPixmap(path_str)
+            if not pixmap.isNull():
+                thumbnail = pixmap.scaled(
+                    selected_list.iconSize(),
+                    Qt.AspectRatioMode.KeepAspectRatio,
+                    Qt.TransformationMode.SmoothTransformation,
+                )
+                item.setIcon(QIcon(thumbnail))
+
+        selected_list.addItem(item)
+        self._selected_paths.add(path_str)
+        self._refresh_selected_captions()
+        self.tabs.setCurrentWidget(self.selectedTab)
+
+    def _remove_selected_items(self) -> None:
+        selected_tab = getattr(self, "selectedTab", None)
+        selected_list: QListWidget | None = (
+            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
+        )
+        if selected_list is None:
+            return
+        for item in selected_list.selectedItems():
+            self._remove_selected_item(item)
+
+    def _remove_single_selected_item(self, item: QListWidgetItem) -> None:
+        self._remove_selected_item(item)
+
+    def _remove_selected_item(self, item: QListWidgetItem) -> None:
+        selected_tab = getattr(self, "selectedTab", None)
+        selected_list: QListWidget | None = (
+            getattr(selected_tab, "listWidget", None) if selected_tab is not None else None
+        )
+        if selected_list is None:
+            return
+        path_data = item.data(Qt.ItemDataRole.UserRole + 1)
+        if path_data:
+            path_str = str(path_data)
+            if path_str in self._selected_paths:
+                self._selected_paths.remove(path_str)
+        selected_list.takeItem(selected_list.row(item))
+        self._refresh_selected_captions()
 
     def update_source_status(self, message: str) -> None:
         status_label = getattr(self.sourcePanel, "statusLabel", None)

--- a/ui/tabs/settings_tab.py
+++ b/ui/tabs/settings_tab.py
@@ -5,14 +5,8 @@ from typing import Dict
 
 from pathlib import Path
 
-from PyQt6.QtCore import Qt, pyqtSignal
-from PyQt6.QtWidgets import (
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import QVBoxLayout, QWidget
 
 from ..config_panel import ConfigPanel
 
@@ -31,25 +25,10 @@ class SettingsTab(QWidget):
 
         self.configPanel = ConfigPanel()
         self.configPanel.optionChanged.connect(self.optionChanged)
+        self.configPanel.outputFolderBrowseRequested.connect(
+            self.outputFolderBrowseRequested.emit
+        )
         layout.addWidget(self.configPanel)
-
-        destination_title = QLabel("Destino das exportações")
-        destination_title.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
-        destination_title.setObjectName("TabTitle")
-        layout.addWidget(destination_title)
-
-        folder_row = QHBoxLayout()
-        folder_row.setSpacing(8)
-
-        self.outputFolderLabel = QLabel("Nenhuma pasta selecionada.")
-        self.outputFolderLabel.setWordWrap(True)
-        folder_row.addWidget(self.outputFolderLabel, 1)
-
-        browse_button = QPushButton("Selecionar pasta…")
-        browse_button.clicked.connect(self.outputFolderBrowseRequested.emit)
-        folder_row.addWidget(browse_button)
-
-        layout.addLayout(folder_row)
         layout.addStretch(1)
 
     def apply_config(self, namespace: str, data: Dict[str, object]) -> None:
@@ -59,7 +38,4 @@ class SettingsTab(QWidget):
         self.configPanel.apply_config(data)
 
     def set_output_folder(self, folder: Path | str | None) -> None:
-        if folder is None:
-            self.outputFolderLabel.setText("Nenhuma pasta selecionada.")
-        else:
-            self.outputFolderLabel.setText(str(folder))
+        self.configPanel.set_output_folder(folder)

--- a/ui/tabs/settings_tab.py
+++ b/ui/tabs/settings_tab.py
@@ -3,16 +3,32 @@ from __future__ import annotations
 
 from typing import Dict
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QLabel, QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget
+from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtWidgets import (
+    QLabel,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+    QWidget,
+)
+
+from ..config_panel import ConfigPanel
 
 
 class SettingsTab(QWidget):
+    """Aggregate generation options and the currently saved configuration."""
+
+    optionChanged = pyqtSignal(str, str, object)
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(18, 18, 18, 18)
-        layout.setSpacing(12)
+        layout.setSpacing(16)
+
+        self.configPanel = ConfigPanel()
+        self.configPanel.optionChanged.connect(self.optionChanged)
+        layout.addWidget(self.configPanel)
 
         title = QLabel("Configuração atual")
         title.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
@@ -29,6 +45,9 @@ class SettingsTab(QWidget):
     def apply_config(self, namespace: str, data: Dict[str, object]) -> None:
         if namespace != "image":
             return
+
+        self.configPanel.apply_config(data)
+
         self.table.setRowCount(0)
         for key, value in data.items():
             row = self.table.rowCount()

--- a/ui/tabs/settings_tab.py
+++ b/ui/tabs/settings_tab.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 
 from typing import Dict
 
+from pathlib import Path
+
 from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
+    QHBoxLayout,
     QLabel,
-    QTableWidget,
-    QTableWidgetItem,
+    QPushButton,
     QVBoxLayout,
     QWidget,
 )
@@ -19,6 +21,7 @@ class SettingsTab(QWidget):
     """Aggregate generation options and the currently saved configuration."""
 
     optionChanged = pyqtSignal(str, str, object)
+    outputFolderBrowseRequested = pyqtSignal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
@@ -30,17 +33,24 @@ class SettingsTab(QWidget):
         self.configPanel.optionChanged.connect(self.optionChanged)
         layout.addWidget(self.configPanel)
 
-        title = QLabel("Configuração atual")
-        title.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
-        title.setObjectName("TabTitle")
-        layout.addWidget(title)
+        destination_title = QLabel("Destino das exportações")
+        destination_title.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        destination_title.setObjectName("TabTitle")
+        layout.addWidget(destination_title)
 
-        self.table = QTableWidget(0, 2)
-        self.table.setHorizontalHeaderLabels(["Chave", "Valor"])
-        self.table.horizontalHeader().setStretchLastSection(True)
-        self.table.verticalHeader().setVisible(False)
-        self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-        layout.addWidget(self.table, 1)
+        folder_row = QHBoxLayout()
+        folder_row.setSpacing(8)
+
+        self.outputFolderLabel = QLabel("Nenhuma pasta selecionada.")
+        self.outputFolderLabel.setWordWrap(True)
+        folder_row.addWidget(self.outputFolderLabel, 1)
+
+        browse_button = QPushButton("Selecionar pasta…")
+        browse_button.clicked.connect(self.outputFolderBrowseRequested.emit)
+        folder_row.addWidget(browse_button)
+
+        layout.addLayout(folder_row)
+        layout.addStretch(1)
 
     def apply_config(self, namespace: str, data: Dict[str, object]) -> None:
         if namespace != "image":
@@ -48,9 +58,8 @@ class SettingsTab(QWidget):
 
         self.configPanel.apply_config(data)
 
-        self.table.setRowCount(0)
-        for key, value in data.items():
-            row = self.table.rowCount()
-            self.table.insertRow(row)
-            self.table.setItem(row, 0, QTableWidgetItem(str(key)))
-            self.table.setItem(row, 1, QTableWidgetItem(str(value)))
+    def set_output_folder(self, folder: Path | str | None) -> None:
+        if folder is None:
+            self.outputFolderLabel.setText("Nenhuma pasta selecionada.")
+        else:
+            self.outputFolderLabel.setText(str(folder))


### PR DESCRIPTION
## Summary
- substituir o painel lateral por um painel de origem com botão de seleção de pasta e lista de arquivos de imagem e texto
- permitir escolher a pasta de saída diretamente no painel direito e persistir a seleção
- atualizar o controlador e o gerenciador de arquivos para dar suporte à nova experiência

## Testing
- python -m compileall gerador-imagem

------
https://chatgpt.com/codex/tasks/task_e_6904bc460ee48326bca8968f351e7ea5