### PR TITLE
Tighten gallery text panes and streamline settings layout

### DIFF
--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -16,11 +16,14 @@ class AppController:
         self.image_manager = ImageManager()
         self.window = MainWindow()
 
-        self.window.configPanel.optionChanged.connect(self._on_option_changed)
+        self.output_directory: Path | None = None
+
+        self.window.settingsTab.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
         self.window.browseFolderRequested.connect(self._on_browse_folder)
-        self.window.configRequested.connect(self._open_settings_tab)
-        self.window.sidebar.folderSelected.connect(self._on_folder_selected)
+        self.window.settingsTab.outputFolderBrowseRequested.connect(
+            self._on_browse_output
+        )
 
         self._initialize_state()
 
@@ -31,32 +34,39 @@ class AppController:
     def _initialize_state(self) -> None:
         image_config = self.config_manager.data.get("image", {})
         self.window.apply_config("image", image_config)
+        output_folder = self.config_manager.get("paths", "output_folder", "")
+        if isinstance(output_folder, str) and output_folder:
+            output_path = Path(output_folder)
+            if output_path.exists():
+                self.output_directory = output_path
+                self.window.settingsTab.set_output_folder(output_path)
+            else:
+                self.output_directory = None
+                self.window.settingsTab.set_output_folder(None)
+        else:
+            self.output_directory = None
+            self.window.settingsTab.set_output_folder(None)
+
         recent = self.config_manager.recent_folders()
         if recent:
-            self.window.set_directories(recent)
-            self.window.select_directory(recent[0])
-            self._load_directory(recent[0])
+            self._select_directory(recent[0])
         else:
-            self._refresh_directories()
-            self.window.update_left_viewer(
-                "Nenhuma pasta selecionada",
-                "Use o painel lateral para escolher uma pasta de imagens.",
+            self.window.set_source_files([])
+            self.window.update_source_status(
+                "Nenhuma pasta selecionada. Use o botão acima para escolher uma pasta.",
             )
-
-    def _refresh_directories(self) -> None:
-        directories = self.image_manager.list_directories()
-        self.window.set_directories(directories)
 
     def _on_option_changed(self, namespace: str, key: str, value) -> None:
         self.config_manager.update(namespace, key, value)
         self.window.apply_config(namespace, self.config_manager.data.get(namespace, {}))
 
     def _on_prompt_submitted(self, prompt: str) -> None:
-        message = (
+        QMessageBox.information(
+            self.window,
+            "Prompt recebido",
             "Prompt recebido! Configure suas opções e utilize as integrações de IA "
-            "para gerar o conteúdo desejado."
+            "para gerar o conteúdo desejado.",
         )
-        self.window.update_right_viewer("Pronto para gerar", message)
         self.window.clear_prompt()
 
     def _on_browse_folder(self) -> None:
@@ -66,13 +76,14 @@ class AppController:
             return
         self._select_directory(folder)
 
-    def _open_settings_tab(self) -> None:
-        index = self.window.tabs.indexOf(self.window.settingsTab)
-        if index >= 0:
-            self.window.tabs.setCurrentIndex(index)
-
-    def _on_folder_selected(self, folder: Path) -> None:
-        self._select_directory(folder)
+    def _on_browse_output(self) -> None:
+        start = self.output_directory or self.image_manager.root_path
+        folder = self.window.open_folder_dialog(start)
+        if folder is None:
+            return
+        self.output_directory = folder
+        self.window.settingsTab.set_output_folder(folder)
+        self.config_manager.update("paths", "output_folder", str(folder))
 
     def _select_directory(self, folder: Path) -> None:
         try:
@@ -85,13 +96,17 @@ class AppController:
             )
             return
         self.config_manager.add_recent_folder(folder)
-        self.window.set_directories(self.config_manager.recent_folders())
-        self.window.select_directory(folder)
         self._load_directory(folder)
 
     def _load_directory(self, folder: Path) -> None:
-        images = self.image_manager.list_images()
-        self.window.set_gallery_images(images)
-        message = f"{len(images)} arquivo(s) de imagem encontrado(s)"
-        self.window.update_left_viewer(folder.name or str(folder), message)
-        self.window.set_path_label(folder)
+        files = self.image_manager.list_media_files()
+        self.window.set_source_folder(folder)
+        self.window.set_source_files(files)
+        if files:
+            message = f"{len(files)} arquivo(s) encontrado(s)"
+        else:
+            message = (
+                "Nenhum arquivo de imagem ou texto encontrado na pasta selecionada."
+            )
+        self.window.update_source_status(message)
+

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -18,10 +18,10 @@ class AppController:
 
         self.output_directory: Path | None = None
 
-        self.window.settingsTab.optionChanged.connect(self._on_option_changed)
+        self.window.configPanel.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
         self.window.browseFolderRequested.connect(self._on_browse_folder)
-        self.window.settingsTab.outputFolderBrowseRequested.connect(
+        self.window.configPanel.outputFolderBrowseRequested.connect(
             self._on_browse_output
         )
 
@@ -39,13 +39,13 @@ class AppController:
             output_path = Path(output_folder)
             if output_path.exists():
                 self.output_directory = output_path
-                self.window.settingsTab.set_output_folder(output_path)
+                self.window.set_output_folder(output_path)
             else:
                 self.output_directory = None
-                self.window.settingsTab.set_output_folder(None)
+                self.window.set_output_folder(None)
         else:
             self.output_directory = None
-            self.window.settingsTab.set_output_folder(None)
+            self.window.set_output_folder(None)
 
         recent = self.config_manager.recent_folders()
         if recent:
@@ -82,7 +82,7 @@ class AppController:
         if folder is None:
             return
         self.output_directory = folder
-        self.window.settingsTab.set_output_folder(folder)
+        self.window.set_output_folder(folder)
         self.config_manager.update("paths", "output_folder", str(folder))
 
     def _select_directory(self, folder: Path) -> None:

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -20,6 +20,9 @@ def _default_config() -> Dict[str, Any]:
             "type": "Imagem",
         },
         "recent_folders": [],
+        "paths": {
+            "output_folder": "",
+        },
     }
 
 

--- a/core/image_manager.py
+++ b/core/image_manager.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import List, Sequence
 
 IMAGE_EXTENSIONS: Sequence[str] = (".png", ".jpg", ".jpeg", ".webp", ".bmp")
+TEXT_EXTENSIONS: Sequence[str] = (".txt",)
+MEDIA_EXTENSIONS: Sequence[str] = IMAGE_EXTENSIONS + TEXT_EXTENSIONS
 
 
 @dataclass
@@ -48,6 +50,16 @@ class ImageManager:
             file
             for file in sorted(base.iterdir())
             if file.is_file() and file.suffix.lower() in IMAGE_EXTENSIONS
+        ]
+
+    def list_media_files(self) -> List[Path]:
+        base = self.current_directory or self.root_path
+        if not base.exists():
+            return []
+        return [
+            file
+            for file in sorted(base.iterdir())
+            if file.is_file() and file.suffix.lower() in MEDIA_EXTENSIONS
         ]
 
     def latest_images(self, limit: int = 10) -> List[Path]:

--- a/ui/config_panel.py
+++ b/ui/config_panel.py
@@ -1,14 +1,17 @@
 """Panel with generation options."""
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Dict, Iterable
 
-from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtCore import Qt, pyqtSignal
 from PyQt6.QtWidgets import (
+    QHBoxLayout,
     QComboBox,
     QFormLayout,
-    QGroupBox,
     QLabel,
+    QPushButton,
+    QSizePolicy,
     QSpinBox,
     QVBoxLayout,
     QWidget,
@@ -19,9 +22,11 @@ class ConfigPanel(QWidget):
     """Expose controls for generation parameters."""
 
     optionChanged = pyqtSignal(str, str, object)
+    outputFolderBrowseRequested = pyqtSignal()
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self._destination_path: str | None = None
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -29,7 +34,7 @@ class ConfigPanel(QWidget):
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(12)
 
-        layout.addWidget(QLabel("Configurações de geração"))
+        control_height = 36
 
         self.sizeCombo = self._create_combo(
             [
@@ -45,20 +50,49 @@ class ConfigPanel(QWidget):
         quantityBox = QSpinBox()
         quantityBox.setRange(1, 10)
         quantityBox.setValue(1)
+        quantityBox.setMinimumHeight(control_height)
+        quantityBox.setSizePolicy(
+            QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        )
         quantityBox.valueChanged.connect(
             lambda value: self.optionChanged.emit("image", "quantity", value)
         )
         self.quantityBox = quantityBox
 
         form = QFormLayout()
+        form.setLabelAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
+        form.setFormAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
+        form.setHorizontalSpacing(12)
+        form.setVerticalSpacing(10)
+        form.setContentsMargins(0, 0, 0, 0)
+        form.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.AllNonFixedFieldsGrow)
         form.addRow("Tamanho", self.sizeCombo)
         form.addRow("Resolução", self.resolutionCombo)
         form.addRow("Quantidade", quantityBox)
         form.addRow("Tipo", self.typeCombo)
 
-        group = QGroupBox()
-        group.setLayout(form)
-        layout.addWidget(group)
+        destination_container = QWidget()
+        destination_layout = QHBoxLayout(destination_container)
+        destination_layout.setContentsMargins(0, 0, 0, 0)
+        destination_layout.setSpacing(8)
+
+        destination_label = QLabel("Nenhuma pasta selecionada.")
+        destination_label.setWordWrap(True)
+        destination_label.setAlignment(Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft)
+        destination_label.setMinimumHeight(control_height)
+        destination_layout.addWidget(destination_label, 1)
+
+        browse_button = QPushButton("Selecionar…")
+        browse_button.setMinimumHeight(control_height)
+        browse_button.clicked.connect(self.outputFolderBrowseRequested.emit)
+        destination_layout.addWidget(browse_button)
+
+        self.destinationLabel = destination_label
+        self.destinationButton = browse_button
+
+        form.addRow("Destino", destination_container)
+
+        layout.addLayout(form)
         layout.addStretch(1)
 
         self.sizeCombo.currentTextChanged.connect(
@@ -70,6 +104,13 @@ class ConfigPanel(QWidget):
         self.typeCombo.currentTextChanged.connect(
             lambda text: self.optionChanged.emit("image", "type", text)
         )
+
+        for widget in (self.sizeCombo, self.resolutionCombo, self.typeCombo):
+            widget.setMinimumHeight(control_height)
+            widget.setSizeAdjustPolicy(QComboBox.SizeAdjustPolicy.AdjustToContents)
+            widget.setSizePolicy(
+                QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+            )
 
     def _create_combo(self, items: Iterable[str]) -> QComboBox:
         combo = QComboBox()
@@ -100,3 +141,26 @@ class ConfigPanel(QWidget):
             index = self.typeCombo.findText(item_type)
             if index >= 0:
                 self.typeCombo.setCurrentIndex(index)
+
+    def set_output_folder(self, folder: Path | str | None) -> None:
+        if folder is None:
+            self._destination_path = None
+            self.destinationLabel.setText("Nenhuma pasta selecionada.")
+            return
+
+        text = str(folder)
+        self._destination_path = text
+        metrics = self.destinationLabel.fontMetrics()
+        available_width = max(0, self.destinationLabel.width())
+        if available_width:
+            elided = metrics.elidedText(text, Qt.TextElideMode.ElideMiddle, available_width)
+            self.destinationLabel.setText(elided)
+        else:
+            self.destinationLabel.setText(text)
+
+    def resizeEvent(self, event):  # type: ignore[override]
+        super().resizeEvent(event)
+        if self._destination_path is None:
+            self.destinationLabel.setText("Nenhuma pasta selecionada.")
+        else:
+            self.set_output_folder(self._destination_path)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -19,14 +19,12 @@ from PyQt6.QtWidgets import (
     QPushButton,
     QSlider,
     QSplitter,
-    QTabWidget,
     QTextEdit,
     QVBoxLayout,
     QWidget,
 )
 
-from .tabs.home_tab import HomeTab
-from .tabs.settings_tab import SettingsTab
+from .config_panel import ConfigPanel
 
 
 class MainWindow(QMainWindow):
@@ -80,20 +78,19 @@ class MainWindow(QMainWindow):
         center_layout.setContentsMargins(12, 16, 12, 16)
         center_layout.setSpacing(12)
 
-        self.tabs = QTabWidget()
-        self.homeTab = HomeTab()
-        self.settingsTab = SettingsTab()
-        self.tabs.addTab(self.homeTab, "Início")
-        self.selectedTab = self._create_selected_tab()
-        self.tabs.addTab(self.selectedTab, "Selecionados")
-        self.tabs.addTab(self.settingsTab, "Configurações")
-        center_layout.addWidget(self.tabs, 1)
+        self.configPanel = ConfigPanel()
+        center_layout.addWidget(self.configPanel)
+
+        self.selectedPanel = self._create_selected_panel()
+        self.selectedPanel.setVisible(False)
+        center_layout.addWidget(self.selectedPanel)
 
         composer = self._create_composer()
         center_layout.addWidget(composer)
 
-        center_layout.setStretch(0, 3)
-        center_layout.setStretch(1, 2)
+        center_layout.setStretch(0, 0)
+        center_layout.setStretch(1, 1)
+        center_layout.setStretch(2, 1)
 
         splitter.addWidget(center)
 
@@ -191,7 +188,7 @@ class MainWindow(QMainWindow):
 
         return frame
 
-    def _create_selected_tab(self) -> QWidget:
+    def _create_selected_panel(self) -> QWidget:
         widget = QWidget()
         layout = QVBoxLayout(widget)
         layout.setContentsMargins(16, 16, 16, 16)
@@ -237,6 +234,7 @@ class MainWindow(QMainWindow):
 
         remove_button = QPushButton("Remover selecionados")
         remove_button.clicked.connect(self._remove_selected_items)
+        remove_button.setEnabled(False)
         layout.addWidget(remove_button)
 
         text_list.itemDoubleClicked.connect(
@@ -376,9 +374,9 @@ class MainWindow(QMainWindow):
                 slider.setValue(size)
                 slider.blockSignals(False)
 
-        selected_tab = getattr(self, "selectedTab", None)
-        if selected_tab is not None:
-            image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+        selected_panel = getattr(self, "selectedPanel", None)
+        if selected_panel is not None:
+            image_list: QListWidget | None = getattr(selected_panel, "imageList", None)
             if image_list is not None:
                 image_list.setIconSize(icon_extent)
                 image_list.setGridSize(QSize(grid_width, grid_height))
@@ -411,17 +409,33 @@ class MainWindow(QMainWindow):
         self._refresh_list_labels(text_list, available_width)
 
     def _refresh_selected_captions(self) -> None:
-        selected_tab = getattr(self, "selectedTab", None)
-        if selected_tab is None:
+        selected_panel = getattr(self, "selectedPanel", None)
+        if selected_panel is None:
             return
-        text_list: QListWidget | None = getattr(selected_tab, "textList", None)
-        image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+        text_list: QListWidget | None = getattr(selected_panel, "textList", None)
+        image_list: QListWidget | None = getattr(selected_panel, "imageList", None)
         if text_list is not None:
             available_text_width = text_list.gridSize().width() - 12
             self._refresh_list_labels(text_list, available_text_width)
         if image_list is not None:
             available_image_width = image_list.gridSize().width() - 24
             self._refresh_list_labels(image_list, available_image_width)
+
+    def _update_selected_visibility(self) -> None:
+        selected_panel = getattr(self, "selectedPanel", None)
+        if selected_panel is None:
+            return
+        text_list: QListWidget | None = getattr(selected_panel, "textList", None)
+        image_list: QListWidget | None = getattr(selected_panel, "imageList", None)
+        has_items = False
+        for lst in (text_list, image_list):
+            if lst is not None and lst.count() > 0:
+                has_items = True
+                break
+        selected_panel.setVisible(has_items)
+        remove_button: QPushButton | None = getattr(selected_panel, "removeButton", None)
+        if remove_button is not None:
+            remove_button.setEnabled(has_items)
 
     def _refresh_list_labels(self, list_widget: QListWidget, width: int) -> None:
         if width <= 0:
@@ -442,14 +456,13 @@ class MainWindow(QMainWindow):
         self._add_selected_file(Path(str(path_data)))
 
     def _add_selected_file(self, path: Path) -> None:
-        selected_tab = getattr(self, "selectedTab", None)
-        if selected_tab is None:
+        selected_panel = getattr(self, "selectedPanel", None)
+        if selected_panel is None:
             return
-        text_list: QListWidget | None = getattr(selected_tab, "textList", None)
-        image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+        text_list: QListWidget | None = getattr(selected_panel, "textList", None)
+        image_list: QListWidget | None = getattr(selected_panel, "imageList", None)
         path_str = str(path)
         if path_str in self._selected_paths:
-            self.tabs.setCurrentWidget(self.selectedTab)
             return
 
         item = QListWidgetItem(path.name)
@@ -476,18 +489,19 @@ class MainWindow(QMainWindow):
                 self._adjust_text_list_height(text_list)
         self._selected_paths.add(path_str)
         self._refresh_selected_captions()
-        self.tabs.setCurrentWidget(self.selectedTab)
+        self._update_selected_visibility()
 
     def _remove_selected_items(self) -> None:
-        selected_tab = getattr(self, "selectedTab", None)
-        if selected_tab is None:
+        selected_panel = getattr(self, "selectedPanel", None)
+        if selected_panel is None:
             return
-        text_list: QListWidget | None = getattr(selected_tab, "textList", None)
-        image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+        text_list: QListWidget | None = getattr(selected_panel, "textList", None)
+        image_list: QListWidget | None = getattr(selected_panel, "imageList", None)
         lists = [lst for lst in (text_list, image_list) if lst is not None]
         for lst in lists:
             for item in lst.selectedItems():
                 self._remove_selected_item(item, lst)
+        self._update_selected_visibility()
 
     def _remove_selected_item(self, item: QListWidgetItem, list_widget: QListWidget) -> None:
         path_data = item.data(Qt.ItemDataRole.UserRole + 1)
@@ -499,6 +513,7 @@ class MainWindow(QMainWindow):
         if list_widget in self._text_lists:
             self._adjust_text_list_height(list_widget)
         self._refresh_selected_captions()
+        self._update_selected_visibility()
 
     def update_source_status(self, message: str) -> None:
         status_label = getattr(self.sourcePanel, "statusLabel", None)
@@ -507,7 +522,10 @@ class MainWindow(QMainWindow):
 
     def apply_config(self, namespace: str, data: dict[str, object]) -> None:
         if namespace == "image":
-            self.settingsTab.apply_config(namespace, data)
+            self.configPanel.apply_config(data)
+
+    def set_output_folder(self, folder: Path | str | None) -> None:
+        self.configPanel.set_output_folder(folder)
 
     def prompt_text(self) -> str:
         return self.promptEdit.toPlainText()

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -2,16 +2,22 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Iterable
+from math import ceil
+from typing import Callable, Iterable
 
-from PyQt6.QtCore import Qt, pyqtSignal
+from PyQt6.QtCore import QEvent, QSize, Qt, pyqtSignal
+from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtWidgets import (
     QFileDialog,
     QFrame,
     QHBoxLayout,
     QLabel,
+    QListView,
     QMainWindow,
+    QListWidget,
+    QListWidgetItem,
     QPushButton,
+    QSlider,
     QSplitter,
     QTabWidget,
     QTextEdit,
@@ -19,9 +25,6 @@ from PyQt6.QtWidgets import (
     QWidget,
 )
 
-from .config_panel import ConfigPanel
-from .sidebar import Sidebar
-from .tabs.gallery_tab import GalleryTab
 from .tabs.home_tab import HomeTab
 from .tabs.settings_tab import SettingsTab
 
@@ -31,12 +34,19 @@ class MainWindow(QMainWindow):
 
     promptSubmitted = pyqtSignal(str)
     browseFolderRequested = pyqtSignal()
-    configRequested = pyqtSignal()
+
+    IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+    TEXT_EXTENSIONS = {".txt"}
 
     def __init__(self) -> None:
         super().__init__()
         self.setWindowTitle("Image Studio IA")
         self.resize(1280, 768)
+        self._image_icon_size = 128
+        self._text_tile_width = 220
+        self._selected_paths: set[str] = set()
+        self._text_lists: list[QListWidget] = []
+        self._max_text_rows = 4
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -46,9 +56,6 @@ class MainWindow(QMainWindow):
         root.setContentsMargins(0, 0, 0, 0)
         root.setSpacing(0)
 
-        self.topbar = self._create_topbar()
-        root.addWidget(self.topbar)
-
         splitter = QSplitter(Qt.Orientation.Horizontal)
         splitter.setChildrenCollapsible(False)
         root.addWidget(splitter, 1)
@@ -57,84 +64,196 @@ class MainWindow(QMainWindow):
         left_layout = QVBoxLayout(left)
         left_layout.setContentsMargins(16, 16, 12, 16)
         left_layout.setSpacing(12)
-
-        self.leftViewer = self._create_viewer("Pasta selecionada")
-        left_layout.addWidget(self.leftViewer)
-
-        self.sidebar = Sidebar()
-        self.sidebar.folderSelected.connect(self._on_folder_selected)
-        self.sidebar.browseRequested.connect(self.browseFolderRequested.emit)
-        left_layout.addWidget(self.sidebar, 1)
-
+        self.sourcePanel = self._create_file_panel(
+            title="Arquivos da pasta selecionada",
+            browse_text="Escolher pasta…",
+            browse_slot=self.browseFolderRequested.emit,
+            status_text="Os arquivos compatíveis serão exibidos aqui.",
+            object_name="SourcePanel",
+            enable_selection=True,
+        )
+        left_layout.addWidget(self.sourcePanel, 1)
         splitter.addWidget(left)
 
-        right = QWidget()
-        right_layout = QVBoxLayout(right)
-        right_layout.setContentsMargins(12, 16, 16, 16)
-        right_layout.setSpacing(12)
-
-        self.rightViewer = self._create_viewer("Saída das imagens geradas")
-        right_layout.addWidget(self.rightViewer)
-
-        self.configPanel = ConfigPanel()
-        right_layout.addWidget(self.configPanel)
+        center = QWidget()
+        center_layout = QVBoxLayout(center)
+        center_layout.setContentsMargins(12, 16, 12, 16)
+        center_layout.setSpacing(12)
 
         self.tabs = QTabWidget()
         self.homeTab = HomeTab()
-        self.galleryTab = GalleryTab()
         self.settingsTab = SettingsTab()
         self.tabs.addTab(self.homeTab, "Início")
-        self.tabs.addTab(self.galleryTab, "Galeria")
+        self.selectedTab = self._create_selected_tab()
+        self.tabs.addTab(self.selectedTab, "Selecionados")
         self.tabs.addTab(self.settingsTab, "Configurações")
-        right_layout.addWidget(self.tabs, 1)
+        center_layout.addWidget(self.tabs, 1)
 
         composer = self._create_composer()
-        right_layout.addWidget(composer)
+        center_layout.addWidget(composer)
 
-        splitter.addWidget(right)
+        center_layout.setStretch(0, 3)
+        center_layout.setStretch(1, 2)
+
+        splitter.addWidget(center)
+
         splitter.setStretchFactor(0, 2)
         splitter.setStretchFactor(1, 3)
 
-    def _create_topbar(self) -> QWidget:
+        self._apply_thumbnail_size(self._image_icon_size)
+
+    def _create_file_panel(
+        self,
+        *,
+        title: str,
+        browse_text: str,
+        browse_slot: Callable[[], None],
+        status_text: str,
+        object_name: str,
+        enable_selection: bool,
+    ) -> QWidget:
         frame = QFrame()
-        frame.setObjectName("TopBar")
-        layout = QHBoxLayout(frame)
-        layout.setContentsMargins(16, 12, 16, 12)
-        layout.setSpacing(12)
-
-        self.brandLabel = QLabel("Image Studio IA")
-        self.brandLabel.setObjectName("BrandLabel")
-        layout.addWidget(self.brandLabel)
-
-        self.pathLabel = QLabel("Pasta: —")
-        self.pathLabel.setObjectName("PathLabel")
-        layout.addWidget(self.pathLabel, 1)
-
-        self.configButton = QPushButton("Configurações")
-        self.configButton.clicked.connect(self.configRequested.emit)
-        layout.addWidget(self.configButton)
-        return frame
-
-    def _create_viewer(self, title: str) -> QWidget:
-        frame = QFrame()
-        frame.setObjectName("Viewer")
+        frame.setObjectName(object_name)
         layout = QVBoxLayout(frame)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(8)
 
-        caption = QLabel(title)
-        caption.setObjectName("ViewerTitle")
-        layout.addWidget(caption)
+        title_label = QLabel(title)
+        title_label.setObjectName(f"{object_name}Title")
+        layout.addWidget(title_label)
 
-        placeholder = QLabel("Selecione uma pasta para visualizar suas imagens")
-        placeholder.setWordWrap(True)
-        placeholder.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        placeholder.setObjectName("ViewerPlaceholder")
-        layout.addWidget(placeholder, 1)
+        browse_button = QPushButton(browse_text)
+        browse_button.clicked.connect(browse_slot)
+        layout.addWidget(browse_button)
 
-        frame.captionLabel = caption  # type: ignore[attr-defined]
-        frame.placeholderLabel = placeholder  # type: ignore[attr-defined]
+        path_label = QLabel("Nenhuma pasta selecionada.")
+        path_label.setWordWrap(True)
+        path_label.setObjectName(f"{object_name}Path")
+        layout.addWidget(path_label)
+
+        status = QLabel(status_text)
+        status.setWordWrap(True)
+        status.setObjectName(f"{object_name}Status")
+        layout.addWidget(status)
+
+        slider_row = QHBoxLayout()
+        slider_caption = QLabel("Tamanho das miniaturas")
+        slider_row.addWidget(slider_caption)
+        thumbnail_slider = QSlider(Qt.Orientation.Horizontal)
+        thumbnail_slider.setObjectName(f"{object_name}ThumbnailSlider")
+        thumbnail_slider.setRange(80, 224)
+        thumbnail_slider.setSingleStep(8)
+        thumbnail_slider.setPageStep(16)
+        thumbnail_slider.setValue(self._image_icon_size)
+        thumbnail_slider.valueChanged.connect(self._update_thumbnail_size)
+        slider_row.addWidget(thumbnail_slider, 1)
+        layout.addLayout(slider_row)
+
+        text_list = QListWidget()
+        text_list.setObjectName(f"{object_name}TextList")
+        text_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
+        text_list.setViewMode(QListView.ViewMode.IconMode)
+        text_list.setResizeMode(QListView.ResizeMode.Adjust)
+        text_list.setMovement(QListView.Movement.Static)
+        text_list.setWrapping(True)
+        text_list.setSpacing(2)
+        text_list.setWordWrap(True)
+        text_list.setGridSize(QSize(self._text_tile_width, 38))
+        text_list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        text_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        layout.addWidget(text_list)
+
+        image_list = QListWidget()
+        image_list.setObjectName(f"{object_name}ImageList")
+        image_list.setSelectionMode(QListWidget.SelectionMode.NoSelection)
+        image_list.setViewMode(QListView.ViewMode.IconMode)
+        image_list.setResizeMode(QListView.ResizeMode.Adjust)
+        image_list.setMovement(QListView.Movement.Static)
+        image_list.setWrapping(True)
+        image_list.setSpacing(3)
+        image_list.setWordWrap(True)
+        image_list.setUniformItemSizes(False)
+        layout.addWidget(image_list, 1)
+
+        frame.thumbnailSlider = thumbnail_slider  # type: ignore[attr-defined]
+        frame.textList = text_list  # type: ignore[attr-defined]
+        frame.imageList = image_list  # type: ignore[attr-defined]
+        frame.pathLabel = path_label  # type: ignore[attr-defined]
+        frame.statusLabel = status  # type: ignore[attr-defined]
+
+        text_list.setVisible(False)
+        text_list.setSizeAdjustPolicy(QListView.SizeAdjustPolicy.AdjustToContents)
+        self._register_text_list(text_list)
+
+        if enable_selection:
+            text_list.itemDoubleClicked.connect(self._handle_source_double_click)
+            image_list.itemDoubleClicked.connect(self._handle_source_double_click)
+
         return frame
+
+    def _create_selected_tab(self) -> QWidget:
+        widget = QWidget()
+        layout = QVBoxLayout(widget)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        description = QLabel(
+            "Arquivos selecionados a partir da pasta de origem. Dê um clique duplo para removê-los."
+        )
+        description.setWordWrap(True)
+        layout.addWidget(description)
+
+        text_list = QListWidget()
+        text_list.setObjectName("SelectedTextList")
+        text_list.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
+        text_list.setViewMode(QListView.ViewMode.IconMode)
+        text_list.setResizeMode(QListView.ResizeMode.Adjust)
+        text_list.setMovement(QListView.Movement.Static)
+        text_list.setWrapping(True)
+        text_list.setSpacing(2)
+        text_list.setWordWrap(True)
+        text_list.setGridSize(QSize(self._text_tile_width, 38))
+        text_list.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        text_list.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        layout.addWidget(text_list)
+
+        image_list = QListWidget()
+        image_list.setObjectName("SelectedImageList")
+        image_list.setSelectionMode(QListWidget.SelectionMode.ExtendedSelection)
+        image_list.setViewMode(QListView.ViewMode.IconMode)
+        image_list.setResizeMode(QListView.ResizeMode.Adjust)
+        image_list.setMovement(QListView.Movement.Static)
+        image_list.setWrapping(True)
+        image_list.setSpacing(3)
+        image_list.setWordWrap(True)
+        image_list.setIconSize(QSize(self._image_icon_size, self._image_icon_size))
+        image_list.setGridSize(
+            QSize(
+                max(self._image_icon_size + 8, int(self._image_icon_size * 1.05)),
+                self._image_icon_size + 28,
+            )
+        )
+        layout.addWidget(image_list, 1)
+
+        remove_button = QPushButton("Remover selecionados")
+        remove_button.clicked.connect(self._remove_selected_items)
+        layout.addWidget(remove_button)
+
+        text_list.itemDoubleClicked.connect(
+            lambda item, list_widget=text_list: self._remove_selected_item(item, list_widget)
+        )
+        image_list.itemDoubleClicked.connect(
+            lambda item, list_widget=image_list: self._remove_selected_item(item, list_widget)
+        )
+
+        widget.textList = text_list  # type: ignore[attr-defined]
+        widget.imageList = image_list  # type: ignore[attr-defined]
+        widget.removeButton = remove_button  # type: ignore[attr-defined]
+
+        text_list.setVisible(False)
+        text_list.setSizeAdjustPolicy(QListView.SizeAdjustPolicy.AdjustToContents)
+        self._register_text_list(text_list)
+        return widget
 
     def _create_composer(self) -> QWidget:
         frame = QFrame()
@@ -142,9 +261,6 @@ class MainWindow(QMainWindow):
         layout = QVBoxLayout(frame)
         layout.setContentsMargins(12, 12, 12, 12)
         layout.setSpacing(8)
-
-        label = QLabel("Prompt ou instruções")
-        layout.addWidget(label)
 
         self.promptEdit = QTextEdit()
         self.promptEdit.setPlaceholderText("Descreva aqui o que deseja gerar…")
@@ -163,41 +279,235 @@ class MainWindow(QMainWindow):
         if text:
             self.promptSubmitted.emit(text)
 
-    def _on_folder_selected(self, folder: Path) -> None:
-        self.set_path_label(folder)
-
     # Public helpers -----------------------------------------------------
-    def set_path_label(self, path: Path) -> None:
-        self.pathLabel.setText(f"Pasta: {path}")
+    def set_source_folder(self, folder: Path) -> None:
+        path_label = getattr(self.sourcePanel, "pathLabel", None)
+        if path_label is not None:
+            path_label.setText(str(folder))
 
-    def set_directories(self, directories: Iterable[Path]) -> None:
-        self.sidebar.set_directories(directories)
+    def set_source_files(self, files: Iterable[Path]) -> None:
+        status_label: QLabel | None = getattr(self.sourcePanel, "statusLabel", None)
+        image_count, text_count = self._populate_panel_files(self.sourcePanel, files)
 
-    def select_directory(self, directory: Path) -> None:
-        self.sidebar.select_folder(directory)
-        self.set_path_label(directory)
+        self._refresh_image_captions(self.sourcePanel)
+        self._refresh_text_captions(self.sourcePanel)
+        self._refresh_selected_captions()
 
-    def set_gallery_images(self, images: Iterable[Path]) -> None:
-        self.galleryTab.set_images(images)
+        if status_label is not None:
+            if image_count == 0 and text_count == 0:
+                status_label.setText("Nenhum arquivo compatível encontrado.")
+            else:
+                parts: list[str] = []
+                if image_count:
+                    parts.append(
+                        f"{image_count} imagem{'s' if image_count != 1 else ''} encontrada"
+                    )
+                if text_count:
+                    parts.append(
+                        f"{text_count} arquivo{'s' if text_count != 1 else ''} de texto"
+                    )
+                status_label.setText(" • ".join(parts))
+
+    def _populate_panel_files(
+        self, panel: QWidget | None, files: Iterable[Path]
+    ) -> tuple[int, int]:
+        image_list: QListWidget | None = getattr(panel, "imageList", None) if panel else None
+        text_list: QListWidget | None = getattr(panel, "textList", None) if panel else None
+        if image_list is None or text_list is None:
+            return (0, 0)
+
+        image_list.clear()
+        text_list.clear()
+
+        thumbnail_size = image_list.iconSize()
+        image_count = 0
+        text_count = 0
+
+        for file in files:
+            suffix = file.suffix.lower()
+            full_path = str(file)
+            item = QListWidgetItem(file.name)
+            item.setToolTip(full_path)
+            item.setData(Qt.ItemDataRole.UserRole, file.name)
+            item.setData(Qt.ItemDataRole.UserRole + 1, full_path)
+            item.setTextAlignment(Qt.AlignmentFlag.AlignHCenter)
+            if suffix in self.IMAGE_EXTENSIONS:
+                pixmap = QPixmap(full_path)
+                if not pixmap.isNull():
+                    thumbnail = pixmap.scaled(
+                        thumbnail_size,
+                        Qt.AspectRatioMode.KeepAspectRatio,
+                        Qt.TransformationMode.SmoothTransformation,
+                    )
+                    item.setIcon(QIcon(thumbnail))
+                image_list.addItem(item)
+                image_count += 1
+            elif suffix in self.TEXT_EXTENSIONS:
+                text_list.addItem(item)
+                text_count += 1
+
+        image_list.setEnabled(image_count > 0)
+        text_list.setEnabled(text_count > 0)
+        self._adjust_text_list_height(text_list)
+        return image_count, text_count
+
+    def _update_thumbnail_size(self, value: int) -> None:
+        self._apply_thumbnail_size(value)
+        self._refresh_image_captions(self.sourcePanel)
+        self._refresh_selected_captions()
+
+    def _apply_thumbnail_size(self, size: int) -> None:
+        self._image_icon_size = size
+        icon_extent = QSize(size, size)
+        padding = 16
+        label_padding = 32
+        grid_width = size + padding
+        grid_height = size + label_padding
+
+        source_panel = getattr(self, "sourcePanel", None)
+        if source_panel is not None:
+            image_list: QListWidget | None = getattr(source_panel, "imageList", None)
+            slider: QSlider | None = getattr(source_panel, "thumbnailSlider", None)
+            if image_list is not None:
+                image_list.setIconSize(icon_extent)
+                image_list.setGridSize(QSize(grid_width, grid_height))
+            if slider is not None and slider.value() != size:
+                slider.blockSignals(True)
+                slider.setValue(size)
+                slider.blockSignals(False)
+
+        selected_tab = getattr(self, "selectedTab", None)
+        if selected_tab is not None:
+            image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+            if image_list is not None:
+                image_list.setIconSize(icon_extent)
+                image_list.setGridSize(QSize(grid_width, grid_height))
+                source_images: QListWidget | None = (
+                    getattr(source_panel, "imageList", None) if source_panel is not None else None
+                )
+                if source_images is not None:
+                    image_list.setSpacing(source_images.spacing())
+
+    def _refresh_image_captions(self, panel: QWidget | None = None) -> None:
+        image_list: QListWidget | None = None
+        if panel is not None:
+            image_list = getattr(panel, "imageList", None)
+        elif hasattr(self, "sourcePanel"):
+            image_list = getattr(self.sourcePanel, "imageList", None)
+        if image_list is None:
+            return
+        available_width = image_list.gridSize().width() - 24
+        self._refresh_list_labels(image_list, available_width)
+
+    def _refresh_text_captions(self, panel: QWidget | None = None) -> None:
+        text_list: QListWidget | None = None
+        if panel is not None:
+            text_list = getattr(panel, "textList", None)
+        elif hasattr(self, "sourcePanel"):
+            text_list = getattr(self.sourcePanel, "textList", None)
+        if text_list is None:
+            return
+        available_width = text_list.gridSize().width() - 12
+        self._refresh_list_labels(text_list, available_width)
+
+    def _refresh_selected_captions(self) -> None:
+        selected_tab = getattr(self, "selectedTab", None)
+        if selected_tab is None:
+            return
+        text_list: QListWidget | None = getattr(selected_tab, "textList", None)
+        image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+        if text_list is not None:
+            available_text_width = text_list.gridSize().width() - 12
+            self._refresh_list_labels(text_list, available_text_width)
+        if image_list is not None:
+            available_image_width = image_list.gridSize().width() - 24
+            self._refresh_list_labels(image_list, available_image_width)
+
+    def _refresh_list_labels(self, list_widget: QListWidget, width: int) -> None:
+        if width <= 0:
+            return
+        metrics = list_widget.fontMetrics()
+        for index in range(list_widget.count()):
+            item = list_widget.item(index)
+            original = item.data(Qt.ItemDataRole.UserRole)
+            if original is None:
+                original = item.text()
+            elided = metrics.elidedText(str(original), Qt.TextElideMode.ElideMiddle, width)
+            item.setText(elided)
+
+    def _handle_source_double_click(self, item: QListWidgetItem) -> None:
+        path_data = item.data(Qt.ItemDataRole.UserRole + 1)
+        if not path_data:
+            return
+        self._add_selected_file(Path(str(path_data)))
+
+    def _add_selected_file(self, path: Path) -> None:
+        selected_tab = getattr(self, "selectedTab", None)
+        if selected_tab is None:
+            return
+        text_list: QListWidget | None = getattr(selected_tab, "textList", None)
+        image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+        path_str = str(path)
+        if path_str in self._selected_paths:
+            self.tabs.setCurrentWidget(self.selectedTab)
+            return
+
+        item = QListWidgetItem(path.name)
+        item.setData(Qt.ItemDataRole.UserRole, path.name)
+        item.setData(Qt.ItemDataRole.UserRole + 1, path_str)
+        item.setToolTip(path_str)
+        item.setTextAlignment(Qt.AlignmentFlag.AlignHCenter)
+
+        image_extensions = {".png", ".jpg", ".jpeg", ".webp", ".bmp"}
+        if path.suffix.lower() in image_extensions:
+            pixmap = QPixmap(path_str)
+            if not pixmap.isNull():
+                thumbnail = pixmap.scaled(
+                    image_list.iconSize() if image_list is not None else QSize(self._image_icon_size, self._image_icon_size),
+                    Qt.AspectRatioMode.KeepAspectRatio,
+                    Qt.TransformationMode.SmoothTransformation,
+                )
+                item.setIcon(QIcon(thumbnail))
+            if image_list is not None:
+                image_list.addItem(item)
+        else:
+            if text_list is not None:
+                text_list.addItem(item)
+                self._adjust_text_list_height(text_list)
+        self._selected_paths.add(path_str)
+        self._refresh_selected_captions()
+        self.tabs.setCurrentWidget(self.selectedTab)
+
+    def _remove_selected_items(self) -> None:
+        selected_tab = getattr(self, "selectedTab", None)
+        if selected_tab is None:
+            return
+        text_list: QListWidget | None = getattr(selected_tab, "textList", None)
+        image_list: QListWidget | None = getattr(selected_tab, "imageList", None)
+        lists = [lst for lst in (text_list, image_list) if lst is not None]
+        for lst in lists:
+            for item in lst.selectedItems():
+                self._remove_selected_item(item, lst)
+
+    def _remove_selected_item(self, item: QListWidgetItem, list_widget: QListWidget) -> None:
+        path_data = item.data(Qt.ItemDataRole.UserRole + 1)
+        if path_data:
+            path_str = str(path_data)
+            if path_str in self._selected_paths:
+                self._selected_paths.remove(path_str)
+        list_widget.takeItem(list_widget.row(item))
+        if list_widget in self._text_lists:
+            self._adjust_text_list_height(list_widget)
+        self._refresh_selected_captions()
+
+    def update_source_status(self, message: str) -> None:
+        status_label = getattr(self.sourcePanel, "statusLabel", None)
+        if status_label is not None:
+            status_label.setText(message)
 
     def apply_config(self, namespace: str, data: dict[str, object]) -> None:
         if namespace == "image":
-            self.configPanel.apply_config(data)
             self.settingsTab.apply_config(namespace, data)
-
-    def update_viewer(self, viewer: QWidget, *, title: str | None = None, message: str | None = None) -> None:
-        caption = getattr(viewer, "captionLabel", None)
-        placeholder = getattr(viewer, "placeholderLabel", None)
-        if title and caption is not None:
-            caption.setText(title)
-        if message and placeholder is not None:
-            placeholder.setText(message)
-
-    def update_left_viewer(self, title: str, message: str) -> None:
-        self.update_viewer(self.leftViewer, title=title, message=message)
-
-    def update_right_viewer(self, title: str, message: str) -> None:
-        self.update_viewer(self.rightViewer, title=title, message=message)
 
     def prompt_text(self) -> str:
         return self.promptEdit.toPlainText()
@@ -215,3 +525,39 @@ class MainWindow(QMainWindow):
             if selected:
                 return Path(selected[0])
         return None
+
+    def _register_text_list(self, list_widget: QListWidget) -> None:
+        self._text_lists.append(list_widget)
+        list_widget.installEventFilter(self)
+
+    def _adjust_text_list_height(self, list_widget: QListWidget | None) -> None:
+        if list_widget is None:
+            return
+        count = list_widget.count()
+        if count == 0:
+            list_widget.setVisible(False)
+            list_widget.setFixedHeight(0)
+            list_widget.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+            return
+
+        list_widget.setVisible(True)
+        grid_size = list_widget.gridSize()
+        grid_width = grid_size.width() or list_widget.viewport().width()
+        grid_height = grid_size.height() or list_widget.sizeHintForRow(0) or 38
+
+        viewport_width = list_widget.viewport().width() or grid_width
+        columns = max(1, viewport_width // max(grid_width, 1))
+        rows = ceil(count / columns)
+        visible_rows = min(rows, self._max_text_rows)
+        total_height = visible_rows * grid_height + max(0, (visible_rows - 1) * list_widget.spacing())
+        frame_padding = list_widget.frameWidth() * 2
+        list_widget.setFixedHeight(total_height + frame_padding)
+        if rows > visible_rows:
+            list_widget.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAsNeeded)
+        else:
+            list_widget.setVerticalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+
+    def eventFilter(self, obj, event):  # type: ignore[override]
+        if event.type() == QEvent.Type.Resize and obj in self._text_lists:
+            self._adjust_text_list_height(obj)  # type: ignore[arg-type]
+        return super().eventFilter(obj, event)

--- a/ui/tabs/settings_tab.py
+++ b/ui/tabs/settings_tab.py
@@ -3,35 +3,39 @@ from __future__ import annotations
 
 from typing import Dict
 
-from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import QLabel, QTableWidget, QTableWidgetItem, QVBoxLayout, QWidget
+from pathlib import Path
+
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import QVBoxLayout, QWidget
+
+from ..config_panel import ConfigPanel
 
 
 class SettingsTab(QWidget):
+    """Aggregate generation options and the currently saved configuration."""
+
+    optionChanged = pyqtSignal(str, str, object)
+    outputFolderBrowseRequested = pyqtSignal()
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         layout = QVBoxLayout(self)
         layout.setContentsMargins(18, 18, 18, 18)
-        layout.setSpacing(12)
+        layout.setSpacing(16)
 
-        title = QLabel("Configuração atual")
-        title.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignTop)
-        title.setObjectName("TabTitle")
-        layout.addWidget(title)
-
-        self.table = QTableWidget(0, 2)
-        self.table.setHorizontalHeaderLabels(["Chave", "Valor"])
-        self.table.horizontalHeader().setStretchLastSection(True)
-        self.table.verticalHeader().setVisible(False)
-        self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
-        layout.addWidget(self.table, 1)
+        self.configPanel = ConfigPanel()
+        self.configPanel.optionChanged.connect(self.optionChanged)
+        self.configPanel.outputFolderBrowseRequested.connect(
+            self.outputFolderBrowseRequested.emit
+        )
+        layout.addWidget(self.configPanel)
+        layout.addStretch(1)
 
     def apply_config(self, namespace: str, data: Dict[str, object]) -> None:
         if namespace != "image":
             return
-        self.table.setRowCount(0)
-        for key, value in data.items():
-            row = self.table.rowCount()
-            self.table.insertRow(row)
-            self.table.setItem(row, 0, QTableWidgetItem(str(key)))
-            self.table.setItem(row, 1, QTableWidgetItem(str(value)))
+
+        self.configPanel.apply_config(data)
+
+    def set_output_folder(self, folder: Path | str | None) -> None:
+        self.configPanel.set_output_folder(folder)


### PR DESCRIPTION
## Summary
- streamline the generation settings form so all controls share consistent sizing, including the inline destination picker
- allow text file sections in the navigation and selected panels to auto-hide when empty while capping their height with scroll support
- adjust thumbnail sizing math so enlarging icons expands the previews with minimal gaps

## Testing
- python -m compileall .
- python -m compileall ui/config_panel.py ui/main_window.py

------
https://chatgpt.com/codex/tasks/task_e_6904bc460ee48326bca8968f351e7ea5