### PR TITLE
Implement OpenAI-powered music scene generation

### DIFF
--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from PyQt6.QtWidgets import QMessageBox
 
 from .config_manager import ConfigManager
+from .content_generator import ContentGenerationError, ContentGenerator
 from .image_manager import ImageManager
 from ui.main_window import MainWindow
 
@@ -15,6 +16,7 @@ class AppController:
         self.config_manager = ConfigManager()
         self.image_manager = ImageManager()
         self.window = MainWindow()
+        self.generator: ContentGenerator | None = None
 
         self.window.configPanel.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
@@ -52,12 +54,72 @@ class AppController:
         self.window.apply_config(namespace, self.config_manager.data.get(namespace, {}))
 
     def _on_prompt_submitted(self, prompt: str) -> None:
-        message = (
-            "Prompt recebido! Configure suas opções e utilize as integrações de IA "
-            "para gerar o conteúdo desejado."
-        )
-        self.window.update_right_viewer("Pronto para gerar", message)
+        item_type = str(
+            self.config_manager.get("image", "type", "Imagem")
+        ).casefold()
+
+        if item_type == "imagem":
+            message = "Função em desenvolvimento"
+            print(message)
+            self.window.update_right_viewer("Função em desenvolvimento", message)
+            self.window.clear_prompt()
+            return
+
+        if item_type in {"música", "musica"}:
+            if not prompt:
+                return
+
+            if self.generator is None:
+                try:
+                    self.generator = ContentGenerator()
+                except ContentGenerationError as error:
+                    self.window.update_right_viewer("Erro", str(error))
+                    print(f"Erro ao configurar o gerador: {error}")
+                    return
+
+            try:
+                result = self.generator.generate_music_scenes(prompt)
+            except ContentGenerationError as error:
+                self.window.update_right_viewer("Erro", str(error))
+                print(f"Erro ao gerar conteúdo: {error}")
+                return
+
+            self._print_music_result(result)
+            self.window.update_right_viewer(
+                "Conteúdo gerado",
+                "O resultado detalhado foi impresso no terminal em formato organizado.",
+            )
+            self.window.clear_prompt()
+            return
+
+        message = "Tipo de conteúdo não suportado."
+        self.window.update_right_viewer("Aviso", message)
+        print(message)
         self.window.clear_prompt()
+
+    def _print_music_result(self, payload: dict[str, object]) -> None:
+        music_title = payload.get("music_title", "")
+        print(f"3.1 - music_title: {music_title}")
+
+        scenes = payload.get("scenes", [])
+        if not isinstance(scenes, list):
+            print("Formato inesperado de cenas.")
+            return
+
+        for scene in scenes:
+            if not isinstance(scene, dict):
+                continue
+            scene_id = scene.get("scene_id")
+            lyric_excerpt = scene.get("lyric_excerpt", "")
+            image_suffix = scene_id if scene_id is not None else "desconhecido"
+            print(f"3.2 - Imagem scene_{image_suffix}.png - {lyric_excerpt}")
+
+            prompt_block = scene.get("prompt", {})
+            if isinstance(prompt_block, dict):
+                print("3.3 - Prompt:")
+                for key, value in prompt_block.items():
+                    print(f"       {key}: {value}")
+            print("-")
 
     def _on_browse_folder(self) -> None:
         start = self.image_manager.current_directory or self.image_manager.root_path

--- a/core/content_generator.py
+++ b/core/content_generator.py
@@ -1,0 +1,167 @@
+"""Integration helpers to communicate with OpenAI's API."""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+from openai import OpenAI
+
+
+SYSTEM_PROMPT = (
+    "Você é um diretor de arte e criador de prompts visuais cinematográficos "
+    "especializado em transformar letras de música em cenas ilustradas.\n"
+    "Receberá uma letra de música e, opcionalmente, uma imagem de referência "
+    "com personagens e estilo visual.\n\n"
+    "Sua tarefa é gerar somente JSON válido, contendo as cenas visuais que "
+    "representam cada pequeno trecho da música.\n\n"
+    "🎵 INSTRUÇÕES\n\n"
+    "Gere automaticamente um nome criativo e coerente para a música, inserindo "
+    "em \"music_title\".\n\n"
+    "Divida a letra em pequenos trechos com sentido próprio — versos, "
+    "expressões ou ações curtas — para formar cenas individuais.\n\n"
+    "Para cada trecho, gere um único prompt completo (sem dependência de "
+    "outros).\n\n"
+    "Se for fornecida uma imagem de referência:\n\n"
+    "O estilo visual e os personagens originais devem ser preservados "
+    "fielmente.\n\n"
+    "A paleta de cores, cenário, iluminação e composição podem ser "
+    "aprimorados criativamente.\n\n"
+    "O campo \"style\" deve incluir algo como:\n\n"
+    "“mantendo o estilo visual e personagens da imagem de referência, com "
+    "aprimoramento criativo de cores e ambiente.”\n\n"
+    "O campo \"characters\" deve especificar:\n\n"
+    "Quais personagens da imagem original aparecem na cena.\n\n"
+    "Se há novos figurantes, descreva-os (ex.: “criança nova observando o "
+    "personagem principal”).\n\n"
+    "Se não houver imagem, defina livremente o estilo coerente com o tom da "
+    "música (ex.: animação infantil 3D colorida, pintura digital poética, arte "
+    "surreal cinematográfica etc.).\n\n"
+    "Não inclua \"aspect_ratio\", \"quality\" ou referências cruzadas.\n\n"
+    "Cada prompt deve ser totalmente autônomo, incluindo todas as informações "
+    "necessárias: ambiente, personagens, ação, emoção, composição e "
+    "iluminação.\n\n"
+    "A saída deve conter apenas JSON válido.\n\n"
+    "🧩 ESTRUTURA DE SAÍDA JSON\n"
+    "{\n"
+    "  \"music_title\": \"nome gerado automaticamente da música\",\n"
+    "  \"scenes\": [\n"
+    "    {\n"
+    "      \"scene_id\": 1,\n"
+    "      \"lyric_excerpt\": \"pequeno trecho da música\",\n"
+    "      \"prompt\": {\n"
+    "        \"style\": \"\",\n"
+    "        \"palette\": \"\",\n"
+    "        \"camera\": \"\",\n"
+    "        \"lighting\": \"\",\n"
+    "        \"environment\": \"\",\n"
+    "        \"characters\": \"\",\n"
+    "        \"action\": \"\",\n"
+    "        \"mood\": \"\",\n"
+    "        \"visual_motifs\": \"\",\n"
+    "        \"framing_composition\": \"\",\n"
+    "        \"negative_prompts\": \"\"\n"
+    "      }\n"
+    "    }\n"
+    "  ]\n"
+    "}\n\n"
+    "🎨 ORIENTAÇÕES CRIATIVAS\n\n"
+    "Cada cena deve representar um quadro cinematográfico ou ilustração isolada, "
+    "visualmente rica.\n\n"
+    "Use descrições técnicas e emocionais:\n"
+    "“plano médio com luz lateral suave”, “contraluz dourado”, “ângulo baixo "
+    "heroico”, “movimento lateral fluido”.\n\n"
+    "Se houver imagem de referência:\n\n"
+    "Estilo e personagens permanecem consistentes.\n\n"
+    "Cores, ambientes e iluminação podem ser reinventados ou aprimorados.\n\n"
+    "Mantenha a coerência geral entre as cenas, mas sem referências diretas "
+    "entre prompts."
+)
+
+
+def _load_dotenv() -> None:
+    """Load key-value pairs from a local ``.env`` file if available."""
+
+    project_root = Path(__file__).resolve().parents[1]
+    env_path = project_root / ".env"
+    if not env_path.exists():
+        return
+
+    try:
+        for line in env_path.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if "=" not in stripped:
+                continue
+            key, value = stripped.split("=", 1)
+            os.environ.setdefault(key.strip(), value.strip())
+    except OSError:
+        # Ignore file reading issues silently to avoid breaking the UI.
+        pass
+
+
+_load_dotenv()
+
+
+class ContentGenerationError(RuntimeError):
+    """Wrap errors raised when contacting OpenAI."""
+
+
+@dataclass
+class ContentGenerator:
+    """Handle the conversation with the OpenAI Responses API."""
+
+    model: str = "gpt-5"
+
+    def __post_init__(self) -> None:
+        api_key = os.getenv("OPENAI_API_KEY")
+        if not api_key:
+            raise ContentGenerationError(
+                "Variável de ambiente OPENAI_API_KEY não configurada."
+            )
+        self._client = OpenAI(api_key=api_key)
+
+    def generate_music_scenes(self, lyrics: str) -> Dict[str, Any]:
+        """Return the structured scenes generated from a lyric."""
+
+        try:
+            response = self._client.responses.create(
+                model=self.model,
+                input=[
+                    {
+                        "role": "system",
+                        "content": [{"type": "text", "text": SYSTEM_PROMPT}],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "Letra da música a ser transformada em cenas visuais:\n"
+                                    f"{lyrics.strip()}"
+                                ),
+                            }
+                        ],
+                    },
+                ],
+                response_format={"type": "json_object"},
+            )
+        except Exception as exc:  # noqa: BLE001 - wrap SDK exceptions
+            raise ContentGenerationError(str(exc)) from exc
+
+        # The Responses API returns a list of content blocks. We expect
+        # the first text block to contain the JSON payload we requested.
+        try:
+            content_block = response.output[0].content[0]
+            text = content_block.text  # type: ignore[attr-defined]
+        except (AttributeError, IndexError, KeyError) as exc:  # pragma: no cover - safety net
+            raise ContentGenerationError("Resposta da API em formato inesperado.") from exc
+
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise ContentGenerationError("A resposta da API não é um JSON válido.") from exc


### PR DESCRIPTION
## Summary
- add an OpenAI content generator to request GPT-5 JSON scenes from music lyrics
- update the controller to route "Gerar conteúdo" requests based on the selected type and print the structured output

## Testing
- python -m compileall core ui

------
https://chatgpt.com/codex/tasks/task_e_690541eb3ddc8326a2801f13ef4edc60