### PR TITLE
Remove OpenAI API calls from controller

### DIFF
--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -1,13 +1,27 @@
 """High level controller that wires managers and the UI together."""
 from __future__ import annotations
 
+import json
+import os
+import re
 from pathlib import Path
+from typing import Any, Dict, List
 
 from PyQt6.QtWidgets import QMessageBox
 
 from .config_manager import ConfigManager
 from .image_manager import ImageManager
 from ui.main_window import MainWindow
+
+try:
+    from dotenv import load_dotenv
+except ImportError:  # pragma: no cover - optional dependency
+    load_dotenv = None  # type: ignore[assignment]
+
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - optional dependency
+    OpenAI = None  # type: ignore[assignment]
 
 
 class AppController:
@@ -17,6 +31,7 @@ class AppController:
         self.window = MainWindow()
 
         self.output_directory: Path | None = None
+        self._openai_client: Any | None = None
 
         self.window.configPanel.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
@@ -82,12 +97,23 @@ class AppController:
             return
 
         self.window.clear_prompt()
+        try:
+            payload = self._request_storyboard(prompt)
+        except Exception as exc:  # pragma: no cover - UI feedback only
+            QMessageBox.critical(
+                self.window,
+                "Erro ao gerar conteúdo",
+                f"Não foi possível gerar o conteúdo solicitado.\n\nDetalhes: {exc}",
+            )
+            return
+
+        self._print_storyboard(payload)
         QMessageBox.information(
             self.window,
-            "Funcionalidade indisponível",
+            "Geração concluída",
             (
-                "A interface está disponível, mas a integração com a API foi removida. "
-                "Use apenas o front-end para organização dos arquivos."
+                "A resposta da API foi processada com sucesso. "
+                "Confira o terminal para visualizar os prompts detalhados."
             ),
         )
 
@@ -131,4 +157,92 @@ class AppController:
                 "Nenhum arquivo de imagem ou texto encontrado na pasta selecionada."
             )
         self.window.update_source_status(message)
+
+    # OpenAI integration -------------------------------------------------
+    def _ensure_client(self) -> Any:
+        if load_dotenv is not None:
+            load_dotenv()
+
+        if OpenAI is None:
+            raise RuntimeError(
+                "O pacote 'openai' não está disponível. Instale-o para usar a geração."
+            )
+
+        if self._openai_client is None:
+            api_key = os.environ.get("OPENAI_API_KEY")
+            if not api_key:
+                raise RuntimeError(
+                    "A variável de ambiente OPENAI_API_KEY não está configurada."
+                )
+            self._openai_client = OpenAI()
+        return self._openai_client
+
+    def _request_storyboard(self, prompt: str) -> Dict[str, Any]:
+        client = self._ensure_client()
+
+        envelope = {
+            "tipo": "json",
+            "conteudo": {
+                "mensagem": prompt,
+            },
+        }
+        json_text = json.dumps(envelope, ensure_ascii=False, indent=2) + "\n"
+
+        response = client.responses.create(  # type: ignore[attr-defined]
+            prompt={
+                "id": "pmpt_6906aa0d5a288194b7def5427da43baf02ed834e4eacfbcd",
+                "version": "3",
+            },
+            input=[
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": json_text,
+                        }
+                    ],
+                }
+            ],
+            reasoning={"summary": "auto"},
+            store=True,
+            include=[
+                "reasoning.encrypted_content",
+                "web_search_call.action.sources",
+            ],
+        )
+
+        content = getattr(response, "output_text", None)
+        if not content:
+            raise RuntimeError("A resposta da API não retornou texto utilizável.")
+
+        payload = json.loads(content)
+        if not isinstance(payload, dict):
+            raise RuntimeError("O conteúdo retornado não está no formato esperado.")
+        return payload
+
+    def _print_storyboard(self, payload: Dict[str, Any]) -> None:
+        music_title = payload.get("music_title", "")
+        print("3.1 - music_title:", music_title)
+
+        scenes: List[Dict[str, Any]] = payload.get("scenes", []) or []
+        for scene in scenes:
+            scene_id = scene.get("scene_id")
+            lyric_excerpt = scene.get("lyric_excerpt", "")
+            slug_source = lyric_excerpt.lower()
+            slug = re.sub(r"[^a-z0-9]+", "-", slug_source).strip("-")
+            if isinstance(scene_id, int):
+                scene_prefix = f"scene_{scene_id:02d}"
+            else:
+                scene_prefix = "scene"
+            image_name = f"{scene_prefix}_{slug}" if slug else scene_prefix
+            print(f"3.2 - {image_name} :: {lyric_excerpt}")
+
+            prompt_content = scene.get("prompt", {})
+            formatted_prompt = json.dumps(
+                prompt_content, ensure_ascii=False, indent=2
+            ) if isinstance(prompt_content, dict) else str(prompt_content)
+            print("3.3 - Prompt:")
+            print(formatted_prompt)
+            print("-" * 40)
 

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -73,6 +73,7 @@ class AppController:
         self._generation_thread: QThread | None = None
         self._generation_worker: _GenerationWorker | None = None
         self._reference_image_blocks: List[Dict[str, Any]] = []
+        self._reference_image_paths: List[Path] = []
 
         self.window.configPanel.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
@@ -360,10 +361,16 @@ class AppController:
 
     def _collect_selected_media(
         self, client: Any, selected_files: List[Path]
-    ) -> Tuple[List[Tuple[str, str]], List[Dict[str, Any]], List[Dict[str, str]]]:
+    ) -> Tuple[
+        List[Tuple[str, str]],
+        List[Dict[str, Any]],
+        List[Dict[str, str]],
+        List[Path],
+    ]:
         texts: List[Tuple[str, str]] = []
         image_contents: List[Dict[str, Any]] = []
         image_refs: List[Dict[str, str]] = []
+        image_paths: List[Path] = []
 
         for path in selected_files:
             suffix = path.suffix.lower()
@@ -384,21 +391,28 @@ class AppController:
                     }
                 )
                 image_refs.append({"nome": path.name, "file_id": file_id})
+                image_paths.append(path)
 
-        return texts, image_contents, image_refs
+        return texts, image_contents, image_refs, image_paths
 
     def _request_storyboard(
         self, prompt: str, selected_files: List[Path]
     ) -> Dict[str, Any]:
         client = self._ensure_client()
 
-        texts, image_contents, image_refs = self._collect_selected_media(
+        (
+            texts,
+            image_contents,
+            image_refs,
+            image_paths,
+        ) = self._collect_selected_media(
             client, selected_files
         )
 
         self._reference_image_blocks = [
             dict(block) for block in image_contents if isinstance(block, dict)
         ]
+        self._reference_image_paths = list(image_paths)
 
         envelope: Dict[str, Any] = {
             "tipo": "json",
@@ -540,7 +554,7 @@ class AppController:
             )
 
             request: Dict[str, Any] = {
-                "model": "gpt-image-1",
+                "model": "gpt-image-1-mini",
                 "prompt": final_prompt,
                 "background": "transparent",
             }
@@ -552,6 +566,7 @@ class AppController:
             render_jobs.append({
                 "file_path": file_path,
                 "request": request,
+                "image_paths": list(self._reference_image_paths),
             })
 
         self._execute_image_batches(client, render_jobs)
@@ -593,10 +608,40 @@ class AppController:
         if not isinstance(request, dict) or not isinstance(file_path, Path):
             return False, "Dados inválidos para renderização da cena."
 
+        image_paths: List[Path] = []
+        raw_image_paths = job.get("image_paths", [])
+        if isinstance(raw_image_paths, list):
+            for path in raw_image_paths:
+                if isinstance(path, Path):
+                    image_paths.append(path)
+                elif isinstance(path, str):
+                    image_paths.append(Path(path))
+
+        request_payload = dict(request)
+        open_files: List[Any] = []
+
+        if image_paths:
+            image_handles: List[Any] = []
+            for path in image_paths:
+                try:
+                    handle = path.open("rb")
+                except OSError:
+                    continue
+                open_files.append(handle)
+                image_handles.append(handle)
+            if image_handles:
+                request_payload["image"] = image_handles
+
         try:
-            response = client.images.generate(**dict(request))  # type: ignore[attr-defined]
+            response = client.images.generate(**request_payload)  # type: ignore[attr-defined]
         except Exception as exc:  # pragma: no cover - API errors
             return False, f"Falha ao gerar a imagem '{file_path.name}': {exc}"
+        finally:
+            for handle in open_files:
+                try:
+                    handle.close()
+                except Exception:
+                    pass
 
         b64_data = self._extract_image_base64(response)
         if not b64_data:

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -5,8 +5,11 @@ import base64
 import json
 import os
 import re
+import time
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from PyQt6.QtCore import QObject, QThread, pyqtSignal
 from PyQt6.QtWidgets import QMessageBox
@@ -512,6 +515,9 @@ class AppController:
             and block.get("type") == "input_image"
             and isinstance(block.get("file_id"), str)
         ]
+
+        render_jobs: List[Dict[str, Any]] = []
+
         for index, scene in enumerate(scenes, start=1):
             scene_id = scene.get("scene_id")
             if isinstance(scene_id, int) and scene_id >= 0:
@@ -529,7 +535,9 @@ class AppController:
                 print(f"Cena {prefix} ignorada: prompt vazio ou inválido.")
                 continue
 
-            final_prompt = self._prepare_image_prompt(prompt_text, reference_blocks, client)
+            final_prompt = self._prepare_image_prompt(
+                prompt_text, reference_blocks, client
+            )
 
             request: Dict[str, Any] = {
                 "model": "gpt-image-1",
@@ -541,35 +549,75 @@ class AppController:
             if quality_option:
                 request["quality"] = quality_option
 
-            try:
-                response = client.images.generate(**request)  # type: ignore[attr-defined]
-            except Exception as exc:  # pragma: no cover - API errors
-                print(f"Falha ao gerar a imagem '{file_path.name}': {exc}")
-                continue
+            render_jobs.append({
+                "file_path": file_path,
+                "request": request,
+            })
 
-            b64_data = self._extract_image_base64(response)
-            if not b64_data:
+        self._execute_image_batches(client, render_jobs)
+
+    def _execute_image_batches(
+        self,
+        client: Any,
+        render_jobs: List[Dict[str, Any]],
+        batch_size: int = 5,
+        interval_seconds: int = 70,
+    ) -> None:
+        if not render_jobs:
+            return
+
+        total_jobs = len(render_jobs)
+        for batch_start in range(0, total_jobs, batch_size):
+            batch = render_jobs[batch_start : batch_start + batch_size]
+            with ThreadPoolExecutor(max_workers=len(batch)) as executor:
+                futures = {
+                    executor.submit(self._render_image_job, client, job): job
+                    for job in batch
+                }
+                for future in as_completed(futures):
+                    _success, message = future.result()
+                    print(message)
+
+            remaining = total_jobs - (batch_start + len(batch))
+            if remaining > 0:
                 print(
-                    f"Não foi possível obter os dados da imagem para '{file_path.name}'."
+                    "Aguardando 70 segundos antes de iniciar a próxima leva de imagens..."
                 )
-                continue
+                time.sleep(interval_seconds)
 
-            try:
-                image_bytes = base64.b64decode(b64_data)
-            except Exception:
-                print(
-                    f"Os dados de imagem retornados são inválidos para '{file_path.name}'."
-                )
-                continue
+    def _render_image_job(
+        self, client: Any, job: Dict[str, Any]
+    ) -> Tuple[bool, str]:
+        file_path = job.get("file_path")
+        request = job.get("request", {})
+        if not isinstance(request, dict) or not isinstance(file_path, Path):
+            return False, "Dados inválidos para renderização da cena."
 
-            try:
-                with open(file_path, "wb") as fh:
-                    fh.write(image_bytes)
-            except OSError:
-                print(f"Não foi possível salvar a imagem: {file_path}")
-                continue
+        try:
+            response = client.images.generate(**dict(request))  # type: ignore[attr-defined]
+        except Exception as exc:  # pragma: no cover - API errors
+            return False, f"Falha ao gerar a imagem '{file_path.name}': {exc}"
 
-            print(f"Imagem gerada: {file_path}")
+        b64_data = self._extract_image_base64(response)
+        if not b64_data:
+            return False, (
+                f"Não foi possível obter os dados da imagem para '{file_path.name}'."
+            )
+
+        try:
+            image_bytes = base64.b64decode(b64_data)
+        except Exception:
+            return False, (
+                f"Os dados de imagem retornados são inválidos para '{file_path.name}'."
+            )
+
+        try:
+            with open(file_path, "wb") as fh:
+                fh.write(image_bytes)
+        except OSError:
+            return False, f"Não foi possível salvar a imagem: {file_path}"
+
+        return True, f"Imagem gerada: {file_path}"
 
     def _resolve_image_generation_settings(self) -> Tuple[str | None, str | None]:
         size_value = self.config_manager.get("image", "size", "auto")

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -73,7 +73,6 @@ class AppController:
         self._generation_thread: QThread | None = None
         self._generation_worker: _GenerationWorker | None = None
         self._reference_image_blocks: List[Dict[str, Any]] = []
-        self._reference_image_paths: List[Path] = []
 
         self.window.configPanel.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
@@ -365,12 +364,10 @@ class AppController:
         List[Tuple[str, str]],
         List[Dict[str, Any]],
         List[Dict[str, str]],
-        List[Path],
     ]:
         texts: List[Tuple[str, str]] = []
         image_contents: List[Dict[str, Any]] = []
         image_refs: List[Dict[str, str]] = []
-        image_paths: List[Path] = []
 
         for path in selected_files:
             suffix = path.suffix.lower()
@@ -391,28 +388,21 @@ class AppController:
                     }
                 )
                 image_refs.append({"nome": path.name, "file_id": file_id})
-                image_paths.append(path)
 
-        return texts, image_contents, image_refs, image_paths
+        return texts, image_contents, image_refs
 
     def _request_storyboard(
         self, prompt: str, selected_files: List[Path]
     ) -> Dict[str, Any]:
         client = self._ensure_client()
 
-        (
-            texts,
-            image_contents,
-            image_refs,
-            image_paths,
-        ) = self._collect_selected_media(
+        texts, image_contents, image_refs = self._collect_selected_media(
             client, selected_files
         )
 
         self._reference_image_blocks = [
             dict(block) for block in image_contents if isinstance(block, dict)
         ]
-        self._reference_image_paths = list(image_paths)
 
         envelope: Dict[str, Any] = {
             "tipo": "json",
@@ -553,21 +543,15 @@ class AppController:
                 prompt_text, reference_blocks, client
             )
 
-            request: Dict[str, Any] = {
-                "model": "gpt-image-1-mini",
-                "prompt": final_prompt,
-                "background": "transparent",
-            }
-            if size_option:
-                request["size"] = size_option
-            if quality_option:
-                request["quality"] = quality_option
-
-            render_jobs.append({
-                "file_path": file_path,
-                "request": request,
-                "image_paths": list(self._reference_image_paths),
-            })
+            render_jobs.append(
+                {
+                    "file_path": file_path,
+                    "prompt": final_prompt,
+                    "image_blocks": [dict(block) for block in reference_blocks],
+                    "size": size_option,
+                    "quality": quality_option,
+                }
+            )
 
         self._execute_image_batches(client, render_jobs)
 
@@ -604,44 +588,56 @@ class AppController:
         self, client: Any, job: Dict[str, Any]
     ) -> Tuple[bool, str]:
         file_path = job.get("file_path")
-        request = job.get("request", {})
-        if not isinstance(request, dict) or not isinstance(file_path, Path):
-            return False, "Dados inválidos para renderização da cena."
+        prompt_text = job.get("prompt")
+        if not isinstance(prompt_text, str) or not prompt_text.strip():
+            return False, "Prompt inválido para renderização da cena."
 
-        image_paths: List[Path] = []
-        raw_image_paths = job.get("image_paths", [])
-        if isinstance(raw_image_paths, list):
-            for path in raw_image_paths:
-                if isinstance(path, Path):
-                    image_paths.append(path)
-                elif isinstance(path, str):
-                    image_paths.append(Path(path))
+        if not isinstance(file_path, Path):
+            return False, "Caminho de arquivo inválido para salvar a cena."
 
-        request_payload = dict(request)
-        open_files: List[Any] = []
-
-        if image_paths:
-            image_handles: List[Any] = []
-            for path in image_paths:
-                try:
-                    handle = path.open("rb")
-                except OSError:
+        raw_blocks = job.get("image_blocks", [])
+        image_blocks: List[Dict[str, Any]] = []
+        if isinstance(raw_blocks, list):
+            for block in raw_blocks:
+                if not isinstance(block, dict):
                     continue
-                open_files.append(handle)
-                image_handles.append(handle)
-            if image_handles:
-                request_payload["image"] = image_handles
+                file_id = block.get("file_id")
+                if isinstance(file_id, str) and file_id:
+                    image_blocks.append({"type": "input_image", "file_id": file_id})
+
+        content_blocks: List[Dict[str, Any]] = [
+            {"type": "input_text", "text": prompt_text}
+        ]
+        content_blocks.extend(image_blocks)
+
+        request_payload: Dict[str, Any] = {
+            "model": "gpt-5",
+            "input": [
+                {
+                    "role": "user",
+                    "content": content_blocks,
+                }
+            ],
+            "tools": [{"type": "image_generation"}],
+        }
+
+        tool_config: Dict[str, Any] = {}
+        size_value = job.get("size")
+        quality_value = job.get("quality")
+        image_generation_config: Dict[str, Any] = {}
+        if isinstance(size_value, str) and size_value:
+            image_generation_config["size"] = size_value
+        if isinstance(quality_value, str) and quality_value:
+            image_generation_config["quality"] = quality_value
+        if image_generation_config:
+            tool_config["image_generation"] = image_generation_config
+        if tool_config:
+            request_payload["tool_config"] = tool_config
 
         try:
-            response = client.images.generate(**request_payload)  # type: ignore[attr-defined]
+            response = client.responses.create(**request_payload)  # type: ignore[attr-defined]
         except Exception as exc:  # pragma: no cover - API errors
             return False, f"Falha ao gerar a imagem '{file_path.name}': {exc}"
-        finally:
-            for handle in open_files:
-                try:
-                    handle.close()
-                except Exception:
-                    pass
 
         b64_data = self._extract_image_base64(response)
         if not b64_data:
@@ -775,7 +771,7 @@ class AppController:
 
         try:
             response = client.responses.create(  # type: ignore[attr-defined]
-                model="gpt-4.1-mini",
+                model="gpt-5",
                 input=[
                     {
                         "role": "user",
@@ -805,31 +801,29 @@ class AppController:
         return prompt_text
 
     def _extract_image_base64(self, response: Any) -> str | None:
-        data = getattr(response, "data", None)
-        if isinstance(data, list) and data:
-            first = data[0]
-            b64_data = getattr(first, "b64_json", None)
-            if isinstance(b64_data, str) and b64_data:
-                return b64_data
-            if isinstance(first, dict):
-                maybe_data = first.get("b64_json")
-                if isinstance(maybe_data, str) and maybe_data:
-                    return maybe_data
+        outputs = getattr(response, "output", None)
+        if isinstance(outputs, list):
+            for item in outputs:
+                item_type = getattr(item, "type", None)
+                if isinstance(item_type, str) and item_type == "image_generation_call":
+                    result = getattr(item, "result", None)
+                    if isinstance(result, str) and result:
+                        return result
+                if isinstance(item, dict):
+                    item_type = item.get("type")
+                    if item_type == "image_generation_call":
+                        result = item.get("result")
+                        if isinstance(result, str) and result:
+                            return result
 
-        json_method = getattr(response, "json", None)
-        if callable(json_method):
-            try:
-                payload = json_method()
-            except Exception:
-                payload = None
-            if isinstance(payload, dict):
-                data_list = payload.get("data")
-                if isinstance(data_list, list) and data_list:
-                    first = data_list[0]
-                    if isinstance(first, dict):
-                        b64_data = first.get("b64_json")
-                        if isinstance(b64_data, str) and b64_data:
-                            return b64_data
+        if isinstance(response, dict):  # pragma: no cover - dict fallback
+            outputs = response.get("output")
+            if isinstance(outputs, list):
+                for item in outputs:
+                    if isinstance(item, dict) and item.get("type") == "image_generation_call":
+                        result = item.get("result")
+                        if isinstance(result, str) and result:
+                            return result
         return None
 
     def _handle_generation_success(self, payload: Dict[str, Any]) -> None:

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -716,16 +716,16 @@ class AppController:
         if not reference_blocks:
             return prompt_text
 
-        content_blocks: List[Dict[str, Any]] = [
-            {"type": "input_text", "text": prompt_text},
-        ]
-        content_blocks.extend(
-            {"type": block["type"], "file_id": block["file_id"]}
+        image_blocks: List[Dict[str, Any]] = [
+            {
+                "type": "input_image",
+                "file_id": block["file_id"],
+            }
             for block in reference_blocks
             if block.get("type") == "input_image" and block.get("file_id")
-        )
+        ]
 
-        if len(content_blocks) == 1:
+        if not image_blocks:
             return prompt_text
 
         try:
@@ -734,7 +734,10 @@ class AppController:
                 input=[
                     {
                         "role": "user",
-                        "content": content_blocks,
+                        "content": [
+                            {"type": "input_text", "text": prompt_text},
+                            *image_blocks,
+                        ],
                     }
                 ],
             )

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -61,13 +61,35 @@ class AppController:
         self.window.apply_config(namespace, self.config_manager.data.get(namespace, {}))
 
     def _on_prompt_submitted(self, prompt: str) -> None:
+        generation_type = (
+            str(self.config_manager.get("image", "type", "Imagem")).strip().lower()
+        )
+
+        if generation_type == "imagem":
+            QMessageBox.information(
+                self.window,
+                "Função em desenvolvimento",
+                "A geração de imagens ainda está em desenvolvimento.",
+            )
+            return
+
+        if generation_type != "música":
+            QMessageBox.warning(
+                self.window,
+                "Tipo não suportado",
+                "O tipo selecionado ainda não é suportado para geração automática.",
+            )
+            return
+
+        self.window.clear_prompt()
         QMessageBox.information(
             self.window,
-            "Prompt recebido",
-            "Prompt recebido! Configure suas opções e utilize as integrações de IA "
-            "para gerar o conteúdo desejado.",
+            "Funcionalidade indisponível",
+            (
+                "A interface está disponível, mas a integração com a API foi removida. "
+                "Use apenas o front-end para organização dos arquivos."
+            ),
         )
-        self.window.clear_prompt()
 
     def _on_browse_folder(self) -> None:
         start = self.image_manager.current_directory or self.image_manager.root_path

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -1,6 +1,7 @@
 """High level controller that wires managers and the UI together."""
 from __future__ import annotations
 
+import base64
 import json
 import os
 import re
@@ -51,6 +52,7 @@ class _GenerationWorker(QObject):
             payload = self._controller._request_storyboard(
                 self._prompt, self._selected_files
             )
+            self._controller._save_storyboard_files(payload)
         except Exception as exc:  # pragma: no cover - worker thread feedback
             self.failed.emit(str(exc))
             return
@@ -494,6 +496,9 @@ class AppController:
             )
             return
 
+        size_option, quality_option = self._resolve_image_generation_settings()
+
+        client = self._ensure_client()
         scenes: List[Dict[str, Any]] = payload.get("scenes", []) or []
         for index, scene in enumerate(scenes, start=1):
             scene_id = scene.get("scene_id")
@@ -504,12 +509,166 @@ class AppController:
 
             lyric_excerpt = str(scene.get("lyric_excerpt", "")).strip()
             excerpt_component = self._sanitize_filename_component(lyric_excerpt)
-            filename = f"{prefix} {excerpt_component}.txt"
+            filename = f"{prefix} {excerpt_component}.png"
             file_path = target_dir / filename
+
+            prompt_text = self._build_image_prompt(lyric_excerpt, scene.get("prompt"))
+            if not prompt_text:
+                print(f"Cena {prefix} ignorada: prompt vazio ou inválido.")
+                continue
+
+            request: Dict[str, Any] = {
+                "model": "gpt-image-1",
+                "prompt": prompt_text,
+                "background": "transparent",
+            }
+            if size_option:
+                request["size"] = size_option
+            if quality_option:
+                request["quality"] = quality_option
+
             try:
-                file_path.write_text("", encoding="utf-8")
+                response = client.images.generate(**request)  # type: ignore[attr-defined]
+            except Exception as exc:  # pragma: no cover - API errors
+                print(f"Falha ao gerar a imagem '{file_path.name}': {exc}")
+                continue
+
+            b64_data = self._extract_image_base64(response)
+            if not b64_data:
+                print(
+                    f"Não foi possível obter os dados da imagem para '{file_path.name}'."
+                )
+                continue
+
+            try:
+                image_bytes = base64.b64decode(b64_data)
+            except Exception:
+                print(
+                    f"Os dados de imagem retornados são inválidos para '{file_path.name}'."
+                )
+                continue
+
+            try:
+                with open(file_path, "wb") as fh:
+                    fh.write(image_bytes)
             except OSError:
-                print(f"Não foi possível criar o arquivo: {file_path}")
+                print(f"Não foi possível salvar a imagem: {file_path}")
+                continue
+
+            print(f"Imagem gerada: {file_path}")
+
+    def _resolve_image_generation_settings(self) -> Tuple[str | None, str | None]:
+        size_value = self.config_manager.get("image", "size", "auto")
+        quality_value = self.config_manager.get("image", "resolution", "auto")
+        return (
+            self._normalize_size_option(size_value),
+            self._normalize_quality_option(quality_value),
+        )
+
+    def _normalize_size_option(self, value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        lowered = cleaned.lower().replace("×", "x")
+        if "auto" in lowered:
+            return None
+        mapping = {
+            "1024x1024 (quadrado)": "1024x1024",
+            "1536x1024 (paisagem)": "1536x1024",
+            "1024x1536 (retrato)": "1024x1536",
+            "1024x1024": "1024x1024",
+            "1536x1024": "1536x1024",
+            "1024x1536": "1024x1536",
+            "1080x1350 (retrato)": "1024x1536",
+            "1080x1920 (vertical/short)": "1024x1536",
+            "1920x1080 (paisagem)": "1536x1024",
+        }
+        if lowered in mapping:
+            return mapping[lowered]
+        match = re.search(r"(\d{3,4})x(\d{3,4})", lowered)
+        if match:
+            candidate = f"{match.group(1)}x{match.group(2)}"
+            if candidate in {"1024x1024", "1536x1024", "1024x1536"}:
+                return candidate
+        return None
+
+    def _normalize_quality_option(self, value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        cleaned = value.strip().lower()
+        if not cleaned or "auto" in cleaned:
+            return None
+        mapping = {
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "baixa": "low",
+            "média": "medium",
+            "media": "medium",
+            "alta": "high",
+        }
+        normalized = mapping.get(cleaned, cleaned)
+        return normalized if normalized in {"low", "medium", "high"} else None
+
+    def _build_image_prompt(self, lyric_excerpt: str, prompt_data: Any) -> str:
+        lines: List[str] = []
+        excerpt = lyric_excerpt.strip()
+        if excerpt:
+            lines.append(f"Trecho da música: {excerpt}")
+
+        if isinstance(prompt_data, dict):
+            for key, value in prompt_data.items():
+                if value is None:
+                    continue
+                if isinstance(value, (list, tuple)):
+                    value_str = ", ".join(str(item) for item in value if item is not None)
+                else:
+                    value_str = str(value)
+                if value_str:
+                    lines.append(f"{key}: {value_str}")
+        elif prompt_data:
+            lines.append(str(prompt_data))
+
+        if lines:
+            return "\n".join(lines)
+
+        if excerpt:
+            return excerpt
+
+        try:
+            return json.dumps({"prompt": prompt_data}, ensure_ascii=False)
+        except TypeError:
+            return ""
+
+    def _extract_image_base64(self, response: Any) -> str | None:
+        data = getattr(response, "data", None)
+        if isinstance(data, list) and data:
+            first = data[0]
+            b64_data = getattr(first, "b64_json", None)
+            if isinstance(b64_data, str) and b64_data:
+                return b64_data
+            if isinstance(first, dict):
+                maybe_data = first.get("b64_json")
+                if isinstance(maybe_data, str) and maybe_data:
+                    return maybe_data
+
+        json_method = getattr(response, "json", None)
+        if callable(json_method):
+            try:
+                payload = json_method()
+            except Exception:
+                payload = None
+            if isinstance(payload, dict):
+                data_list = payload.get("data")
+                if isinstance(data_list, list) and data_list:
+                    first = data_list[0]
+                    if isinstance(first, dict):
+                        b64_data = first.get("b64_json")
+                        if isinstance(b64_data, str) and b64_data:
+                            return b64_data
+        return None
 
     def _handle_generation_success(self, payload: Dict[str, Any]) -> None:
         elapsed_message = None
@@ -522,7 +681,6 @@ class AppController:
         self._finalize_generation_thread()
 
         self._print_storyboard(payload)
-        self._save_storyboard_files(payload)
         QMessageBox.information(
             self.window,
             "Geração concluída",

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -119,6 +119,7 @@ class AppController:
             return
 
         self._print_storyboard(payload)
+        self._save_storyboard_files(payload)
         QMessageBox.information(
             self.window,
             "Geração concluída",
@@ -434,4 +435,49 @@ class AppController:
             print("3.3 - Prompt:")
             print(formatted_prompt)
             print("-" * 40)
+
+    # Output helpers ---------------------------------------------------
+    def _sanitize_filename_component(self, value: str) -> str:
+        value = value.replace("\n", " ").replace("\r", " ")
+        value = " ".join(value.split())
+        sanitized = re.sub(r"[\\/:*?\"<>|]", "_", value).strip(" _")
+        if len(sanitized) > 80:
+            sanitized = sanitized[:80].rstrip(" _")
+        return sanitized or "sem_nome"
+
+    def _save_storyboard_files(self, payload: Dict[str, Any]) -> None:
+        if self.output_directory is None:
+            print(
+                "Nenhuma pasta de destino configurada. Os arquivos de cenas não foram criados."
+            )
+            return
+
+        music_title = str(payload.get("music_title", "")).strip()
+        folder_name = self._sanitize_filename_component(music_title or "sem_titulo")
+        target_dir = self.output_directory / folder_name
+
+        try:
+            target_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            print(
+                "Não foi possível criar a pasta de destino para salvar as cenas geradas."
+            )
+            return
+
+        scenes: List[Dict[str, Any]] = payload.get("scenes", []) or []
+        for index, scene in enumerate(scenes, start=1):
+            scene_id = scene.get("scene_id")
+            if isinstance(scene_id, int) and scene_id >= 0:
+                prefix = f"{scene_id:03d}"
+            else:
+                prefix = f"{index:03d}"
+
+            lyric_excerpt = str(scene.get("lyric_excerpt", "")).strip()
+            excerpt_component = self._sanitize_filename_component(lyric_excerpt)
+            filename = f"{prefix} {excerpt_component}.txt"
+            file_path = target_dir / filename
+            try:
+                file_path.write_text("", encoding="utf-8")
+            except OSError:
+                print(f"Não foi possível criar o arquivo: {file_path}")
 

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -69,6 +69,7 @@ class AppController:
         self._openai_client: Any | None = None
         self._generation_thread: QThread | None = None
         self._generation_worker: _GenerationWorker | None = None
+        self._reference_image_blocks: List[Dict[str, Any]] = []
 
         self.window.configPanel.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
@@ -392,6 +393,10 @@ class AppController:
             client, selected_files
         )
 
+        self._reference_image_blocks = [
+            dict(block) for block in image_contents if isinstance(block, dict)
+        ]
+
         envelope: Dict[str, Any] = {
             "tipo": "json",
             "conteudo": {
@@ -500,6 +505,13 @@ class AppController:
 
         client = self._ensure_client()
         scenes: List[Dict[str, Any]] = payload.get("scenes", []) or []
+        reference_blocks = [
+            dict(block)
+            for block in getattr(self, "_reference_image_blocks", [])
+            if isinstance(block, dict)
+            and block.get("type") == "input_image"
+            and isinstance(block.get("file_id"), str)
+        ]
         for index, scene in enumerate(scenes, start=1):
             scene_id = scene.get("scene_id")
             if isinstance(scene_id, int) and scene_id >= 0:
@@ -517,9 +529,11 @@ class AppController:
                 print(f"Cena {prefix} ignorada: prompt vazio ou inválido.")
                 continue
 
+            final_prompt = self._prepare_image_prompt(prompt_text, reference_blocks, client)
+
             request: Dict[str, Any] = {
                 "model": "gpt-image-1",
-                "prompt": prompt_text,
+                "prompt": final_prompt,
                 "background": "transparent",
             }
             if size_option:
@@ -641,6 +655,58 @@ class AppController:
             return json.dumps({"prompt": prompt_data}, ensure_ascii=False)
         except TypeError:
             return ""
+
+    def _prepare_image_prompt(
+        self,
+        prompt_text: str,
+        reference_blocks: List[Dict[str, Any]],
+        client: Any,
+    ) -> str:
+        if not prompt_text.strip():
+            return prompt_text
+
+        if not reference_blocks:
+            return prompt_text
+
+        content_blocks: List[Dict[str, Any]] = [
+            {"type": "input_text", "text": prompt_text},
+        ]
+        content_blocks.extend(
+            {"type": block["type"], "file_id": block["file_id"]}
+            for block in reference_blocks
+            if block.get("type") == "input_image" and block.get("file_id")
+        )
+
+        if len(content_blocks) == 1:
+            return prompt_text
+
+        try:
+            response = client.responses.create(  # type: ignore[attr-defined]
+                model="gpt-4.1-mini",
+                input=[
+                    {
+                        "role": "user",
+                        "content": content_blocks,
+                    }
+                ],
+            )
+        except Exception:
+            return prompt_text
+
+        maybe_text = getattr(response, "output_text", None)
+        if isinstance(maybe_text, str):
+            cleaned = maybe_text.strip()
+            if cleaned:
+                return cleaned
+
+        if isinstance(response, dict):  # pragma: no cover - fallback for dict responses
+            maybe_text = response.get("output_text")
+            if isinstance(maybe_text, str):
+                cleaned = maybe_text.strip()
+                if cleaned:
+                    return cleaned
+
+        return prompt_text
 
     def _extract_image_base64(self, response: Any) -> str | None:
         data = getattr(response, "data", None)

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -7,6 +7,7 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+from PyQt6.QtCore import QObject, QThread, pyqtSignal
 from PyQt6.QtWidgets import QMessageBox
 
 from .config_manager import ConfigManager
@@ -35,6 +36,27 @@ except ImportError:  # pragma: no cover - optional dependency
     UnidentifiedImageError = Exception  # type: ignore[assignment]
 
 
+class _GenerationWorker(QObject):
+    finished = pyqtSignal(dict)
+    failed = pyqtSignal(str)
+
+    def __init__(self, controller: "AppController", prompt: str, selected_files: List[Path]) -> None:
+        super().__init__()
+        self._controller = controller
+        self._prompt = prompt
+        self._selected_files = selected_files
+
+    def run(self) -> None:
+        try:
+            payload = self._controller._request_storyboard(
+                self._prompt, self._selected_files
+            )
+        except Exception as exc:  # pragma: no cover - worker thread feedback
+            self.failed.emit(str(exc))
+            return
+        self.finished.emit(payload)
+
+
 class AppController:
     def __init__(self) -> None:
         self.config_manager = ConfigManager()
@@ -43,6 +65,8 @@ class AppController:
 
         self.output_directory: Path | None = None
         self._openai_client: Any | None = None
+        self._generation_thread: QThread | None = None
+        self._generation_worker: _GenerationWorker | None = None
 
         self.window.configPanel.optionChanged.connect(self._on_option_changed)
         self.window.promptSubmitted.connect(self._on_prompt_submitted)
@@ -107,27 +131,30 @@ class AppController:
             )
             return
 
-        self.window.clear_prompt()
-        try:
-            payload = self._request_storyboard(prompt)
-        except Exception as exc:  # pragma: no cover - UI feedback only
-            QMessageBox.critical(
+        if self._generation_thread is not None:
+            QMessageBox.information(
                 self.window,
-                "Erro ao gerar conteúdo",
-                f"Não foi possível gerar o conteúdo solicitado.\n\nDetalhes: {exc}",
+                "Processo em andamento",
+                "Já existe uma requisição em andamento. Aguarde a conclusão antes de iniciar outra.",
             )
             return
 
-        self._print_storyboard(payload)
-        self._save_storyboard_files(payload)
-        QMessageBox.information(
-            self.window,
-            "Geração concluída",
-            (
-                "A resposta da API foi processada com sucesso. "
-                "Confira o terminal para visualizar os prompts detalhados."
-            ),
-        )
+        self.window.clear_prompt()
+        self.window.begin_generation_progress()
+
+        selected_files = list(self.window.selected_files())
+
+        worker = _GenerationWorker(self, prompt, selected_files)
+        thread = QThread()
+        worker.moveToThread(thread)
+        worker.finished.connect(self._handle_generation_success)
+        worker.failed.connect(self._handle_generation_failure)
+        thread.started.connect(worker.run)
+        thread.finished.connect(thread.deleteLater)
+        thread.start()
+
+        self._generation_thread = thread
+        self._generation_worker = worker
 
     def _on_browse_folder(self) -> None:
         start = self.image_manager.current_directory or self.image_manager.root_path
@@ -326,13 +353,12 @@ class AppController:
         return None
 
     def _collect_selected_media(
-        self, client: Any
+        self, client: Any, selected_files: List[Path]
     ) -> Tuple[List[Tuple[str, str]], List[Dict[str, Any]], List[Dict[str, str]]]:
         texts: List[Tuple[str, str]] = []
         image_contents: List[Dict[str, Any]] = []
         image_refs: List[Dict[str, str]] = []
 
-        selected_files = self.window.selected_files()
         for path in selected_files:
             suffix = path.suffix.lower()
             if suffix in TEXT_EXTENSIONS:
@@ -355,10 +381,14 @@ class AppController:
 
         return texts, image_contents, image_refs
 
-    def _request_storyboard(self, prompt: str) -> Dict[str, Any]:
+    def _request_storyboard(
+        self, prompt: str, selected_files: List[Path]
+    ) -> Dict[str, Any]:
         client = self._ensure_client()
 
-        texts, image_contents, image_refs = self._collect_selected_media(client)
+        texts, image_contents, image_refs = self._collect_selected_media(
+            client, selected_files
+        )
 
         envelope: Dict[str, Any] = {
             "tipo": "json",
@@ -480,4 +510,57 @@ class AppController:
                 file_path.write_text("", encoding="utf-8")
             except OSError:
                 print(f"Não foi possível criar o arquivo: {file_path}")
+
+    def _handle_generation_success(self, payload: Dict[str, Any]) -> None:
+        elapsed_message = None
+        if self.window is not None:
+            elapsed_seconds = getattr(self.window, "_generation_elapsed", 0)
+            if isinstance(elapsed_seconds, int) and elapsed_seconds > 0:
+                elapsed_message = f"Concluído em {elapsed_seconds} s"
+
+        self.window.finish_generation_progress(message=elapsed_message)
+        self._finalize_generation_thread()
+
+        self._print_storyboard(payload)
+        self._save_storyboard_files(payload)
+        QMessageBox.information(
+            self.window,
+            "Geração concluída",
+            (
+                "A resposta da API foi processada com sucesso. "
+                "Confira o terminal para visualizar os prompts detalhados."
+            ),
+        )
+
+    def _handle_generation_failure(self, error_message: str) -> None:
+        elapsed_message = None
+        if self.window is not None:
+            elapsed_seconds = getattr(self.window, "_generation_elapsed", 0)
+            if isinstance(elapsed_seconds, int) and elapsed_seconds > 0:
+                elapsed_message = f"Falha após {elapsed_seconds} s"
+
+        self.window.finish_generation_progress(message=elapsed_message)
+        self._finalize_generation_thread()
+        QMessageBox.critical(
+            self.window,
+            "Erro ao gerar conteúdo",
+            (
+                "Não foi possível gerar o conteúdo solicitado."
+                f"\n\nDetalhes: {error_message}"
+            ),
+        )
+
+    def _finalize_generation_thread(self) -> None:
+        thread = self._generation_thread
+        worker = self._generation_worker
+
+        self._generation_thread = None
+        self._generation_worker = None
+
+        if worker is not None:
+            worker.deleteLater()
+
+        if thread is not None:
+            thread.quit()
+            thread.wait()
 

--- a/core/app_controller.py
+++ b/core/app_controller.py
@@ -5,12 +5,12 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from PyQt6.QtWidgets import QMessageBox
 
 from .config_manager import ConfigManager
-from .image_manager import ImageManager
+from .image_manager import IMAGE_EXTENSIONS, TEXT_EXTENSIONS, ImageManager
 from ui.main_window import MainWindow
 
 try:
@@ -22,6 +22,17 @@ try:
     from openai import OpenAI
 except ImportError:  # pragma: no cover - optional dependency
     OpenAI = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from PIL import Image, PngImagePlugin
+except ImportError:  # pragma: no cover - optional dependency
+    Image = None  # type: ignore[assignment]
+    PngImagePlugin = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional dependency
+    from PIL import UnidentifiedImageError
+except ImportError:  # pragma: no cover - optional dependency
+    UnidentifiedImageError = Exception  # type: ignore[assignment]
 
 
 class AppController:
@@ -177,16 +188,199 @@ class AppController:
             self._openai_client = OpenAI()
         return self._openai_client
 
+    # Metadata helpers -------------------------------------------------
+    def _load_sidecar_metadata(self, path: Path) -> Dict[str, str]:
+        metadata_path = path.with_suffix(path.suffix + ".meta.json")
+        if not metadata_path.exists():
+            return {}
+        try:
+            data = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return {str(k): str(v) for k, v in data.items() if isinstance(k, str)}
+
+    def _save_sidecar_metadata(self, path: Path, data: Dict[str, str]) -> None:
+        metadata_path = path.with_suffix(path.suffix + ".meta.json")
+        try:
+            metadata_path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+        except OSError:
+            pass
+
+    def _decode_exif_user_comment(self, value: Any) -> str:
+        if isinstance(value, bytes):
+            prefixes = (
+                b"ASCII\0\0\0",
+                b"JIS\0\0\0\0",
+                b"UNICODE\0",
+            )
+            for prefix in prefixes:
+                if value.startswith(prefix):
+                    value = value[len(prefix) :]
+                    break
+            try:
+                return value.decode("utf-8", "ignore")
+            except Exception:
+                return ""
+        if isinstance(value, str):
+            return value
+        return ""
+
+    def _encode_exif_user_comment(self, data: Dict[str, str]) -> bytes:
+        payload = json.dumps(data, ensure_ascii=False)
+        return b"UNICODE\0" + payload.encode("utf-8")
+
+    def _load_image_metadata(self, path: Path) -> Dict[str, str]:
+        metadata: Dict[str, str] = {}
+        metadata.update(self._load_sidecar_metadata(path))
+        if Image is None:
+            return metadata
+
+        suffix = path.suffix.lower()
+        try:
+            with Image.open(path) as img:
+                if suffix == ".png":
+                    for key, value in img.info.items():
+                        if isinstance(key, str) and isinstance(value, str):
+                            metadata.setdefault(key, value)
+                elif suffix in {".jpg", ".jpeg", ".webp"}:
+                    exif = img.getexif()
+                    if exif:
+                        decoded = self._decode_exif_user_comment(exif.get(0x9286))
+                        if decoded:
+                            try:
+                                payload = json.loads(decoded)
+                                if isinstance(payload, dict):
+                                    for key, value in payload.items():
+                                        if isinstance(key, str) and isinstance(value, str):
+                                            metadata.setdefault(key, value)
+                            except json.JSONDecodeError:
+                                metadata.setdefault("IDOPENAI", decoded)
+        except (OSError, UnidentifiedImageError):  # pragma: no cover - best effort only
+            return metadata
+        return metadata
+
+    def _write_png_metadata(self, path: Path, data: Dict[str, str]) -> bool:
+        if Image is None or PngImagePlugin is None:
+            return False
+        try:
+            with Image.open(path) as img:
+                pnginfo = PngImagePlugin.PngInfo()
+                for key, value in img.info.items():
+                    if isinstance(key, str) and isinstance(value, str):
+                        pnginfo.add_text(key, value)
+                for key, value in data.items():
+                    pnginfo.add_text(key, value)
+                img.save(path, pnginfo=pnginfo)
+            return True
+        except (OSError, UnidentifiedImageError):  # pragma: no cover - best effort only
+            return False
+
+    def _write_jpeg_like_metadata(self, path: Path, data: Dict[str, str]) -> bool:
+        if Image is None:
+            return False
+        try:
+            with Image.open(path) as img:
+                exif = img.getexif()
+                exif[0x9286] = self._encode_exif_user_comment(data)
+                img.save(path, exif=exif.tobytes())
+            return True
+        except (OSError, UnidentifiedImageError):  # pragma: no cover - best effort only
+            return False
+
+    def _write_image_metadata(self, path: Path, data: Dict[str, str]) -> None:
+        success = False
+        suffix = path.suffix.lower()
+        if suffix == ".png":
+            success = self._write_png_metadata(path, data)
+        elif suffix in {".jpg", ".jpeg", ".webp"}:
+            success = self._write_jpeg_like_metadata(path, data)
+
+        if not success:
+            merged = self._load_sidecar_metadata(path)
+            merged.update(data)
+            self._save_sidecar_metadata(path, merged)
+        else:
+            merged = self._load_sidecar_metadata(path)
+            merged.update(data)
+            self._save_sidecar_metadata(path, merged)
+
+    def _ensure_openai_file_id(self, path: Path, client: Any) -> str | None:
+        metadata = self._load_image_metadata(path)
+        existing = metadata.get("IDOPENAI")
+        if existing:
+            return existing
+
+        try:
+            with open(path, "rb") as buffer:
+                result = client.files.create(file=buffer, purpose="vision")
+        except OSError:
+            return None
+        except Exception:  # pragma: no cover - API errors
+            return None
+
+        file_id = getattr(result, "id", None)
+        if isinstance(file_id, str) and file_id:
+            self._write_image_metadata(path, {"IDOPENAI": file_id})
+            return file_id
+        return None
+
+    def _collect_selected_media(
+        self, client: Any
+    ) -> Tuple[List[Tuple[str, str]], List[Dict[str, Any]], List[Dict[str, str]]]:
+        texts: List[Tuple[str, str]] = []
+        image_contents: List[Dict[str, Any]] = []
+        image_refs: List[Dict[str, str]] = []
+
+        selected_files = self.window.selected_files()
+        for path in selected_files:
+            suffix = path.suffix.lower()
+            if suffix in TEXT_EXTENSIONS:
+                try:
+                    content = path.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    continue
+                texts.append((path.name, content))
+            elif suffix in IMAGE_EXTENSIONS:
+                file_id = self._ensure_openai_file_id(path, client)
+                if not file_id:
+                    continue
+                image_contents.append(
+                    {
+                        "type": "input_image",
+                        "file_id": file_id,
+                    }
+                )
+                image_refs.append({"nome": path.name, "file_id": file_id})
+
+        return texts, image_contents, image_refs
+
     def _request_storyboard(self, prompt: str) -> Dict[str, Any]:
         client = self._ensure_client()
 
-        envelope = {
+        texts, image_contents, image_refs = self._collect_selected_media(client)
+
+        envelope: Dict[str, Any] = {
             "tipo": "json",
             "conteudo": {
                 "mensagem": prompt,
             },
         }
+        if texts:
+            envelope["conteudo"]["arquivos_texto"] = [
+                {"nome": name, "conteudo": content} for name, content in texts
+            ]
+        if image_refs:
+            envelope["conteudo"]["referencias_imagem"] = image_refs
+
         json_text = json.dumps(envelope, ensure_ascii=False, indent=2) + "\n"
+
+        content_blocks: List[Dict[str, Any]] = [
+            {
+                "type": "input_text",
+                "text": json_text,
+            }
+        ]
+        content_blocks.extend(image_contents)
 
         response = client.responses.create(  # type: ignore[attr-defined]
             prompt={
@@ -196,12 +390,7 @@ class AppController:
             input=[
                 {
                     "role": "user",
-                    "content": [
-                        {
-                            "type": "input_text",
-                            "text": json_text,
-                        }
-                    ],
+                    "content": content_blocks,
                 }
             ],
             reasoning={"summary": "auto"},

--- a/core/config_manager.py
+++ b/core/config_manager.py
@@ -14,8 +14,8 @@ CONFIG_FILE_NAME = ".image_studio_config.json"
 def _default_config() -> Dict[str, Any]:
     return {
         "image": {
-            "size": "1024 × 1024 (Quadrado)",
-            "resolution": "Baixa",
+            "size": "auto",
+            "resolution": "auto",
             "quantity": 1,
             "type": "Imagem",
         },

--- a/ui/config_panel.py
+++ b/ui/config_panel.py
@@ -1,6 +1,7 @@
 """Panel with generation options."""
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Dict, Iterable
 
@@ -38,13 +39,20 @@ class ConfigPanel(QWidget):
 
         self.sizeCombo = self._create_combo(
             [
-                "1080 × 1350 (Retrato)",
-                "1024 × 1024 (Quadrado)",
-                "1920 × 1080 (Paisagem)",
-                "1080 × 1920 (Vertical/Short)",
+                ("1024x1024 (quadrado)", "1024x1024"),
+                ("1536x1024 (paisagem)", "1536x1024"),
+                ("1024x1536 (retrato)", "1024x1536"),
+                ("auto (padrão)", "auto"),
             ]
         )
-        self.resolutionCombo = self._create_combo(["Baixa", "Média", "Alta"])
+        self.resolutionCombo = self._create_combo(
+            [
+                ("low", "low"),
+                ("medium", "medium"),
+                ("high", "high"),
+                ("auto (padrão)", "auto"),
+            ]
+        )
         self.typeCombo = self._create_combo(["Imagem", "Música"])
 
         quantityBox = QSpinBox()
@@ -95,11 +103,15 @@ class ConfigPanel(QWidget):
         layout.addLayout(form)
         layout.addStretch(1)
 
-        self.sizeCombo.currentTextChanged.connect(
-            lambda text: self.optionChanged.emit("image", "size", text)
+        self.sizeCombo.currentIndexChanged.connect(
+            lambda index: self.optionChanged.emit(
+                "image", "size", self._combo_value(self.sizeCombo, index)
+            )
         )
-        self.resolutionCombo.currentTextChanged.connect(
-            lambda text: self.optionChanged.emit("image", "resolution", text)
+        self.resolutionCombo.currentIndexChanged.connect(
+            lambda index: self.optionChanged.emit(
+                "image", "resolution", self._combo_value(self.resolutionCombo, index)
+            )
         )
         self.typeCombo.currentTextChanged.connect(
             lambda text: self.optionChanged.emit("image", "type", text)
@@ -112,10 +124,14 @@ class ConfigPanel(QWidget):
                 QSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
             )
 
-    def _create_combo(self, items: Iterable[str]) -> QComboBox:
+    def _create_combo(self, items: Iterable[tuple[str, object] | str]) -> QComboBox:
         combo = QComboBox()
         for item in items:
-            combo.addItem(item)
+            if isinstance(item, tuple):
+                text, value = item
+                combo.addItem(text, value)
+            else:
+                combo.addItem(item)
         return combo
 
     def apply_config(self, data: Dict[str, object]) -> None:
@@ -125,14 +141,12 @@ class ConfigPanel(QWidget):
         item_type = data.get("type")
 
         if isinstance(size, str):
-            index = self.sizeCombo.findText(size)
-            if index >= 0:
-                self.sizeCombo.setCurrentIndex(index)
+            normalized = self._normalize_size_value(size)
+            self._set_combo_index_by_value(self.sizeCombo, normalized)
 
         if isinstance(resolution, str):
-            index = self.resolutionCombo.findText(resolution)
-            if index >= 0:
-                self.resolutionCombo.setCurrentIndex(index)
+            normalized = self._normalize_resolution_value(resolution)
+            self._set_combo_index_by_value(self.resolutionCombo, normalized)
 
         if isinstance(quantity, int):
             self.quantityBox.setValue(quantity)
@@ -164,3 +178,62 @@ class ConfigPanel(QWidget):
             self.destinationLabel.setText("Nenhuma pasta selecionada.")
         else:
             self.set_output_folder(self._destination_path)
+
+    def _combo_value(self, combo: QComboBox, index: int) -> object:
+        value = combo.itemData(index)
+        if value is None:
+            return combo.itemText(index)
+        return value
+
+    def _set_combo_index_by_value(self, combo: QComboBox, value: str) -> None:
+        index = self._find_index_by_data(combo, value)
+        if index < 0 and isinstance(value, str):
+            index = combo.findText(value)
+        if index >= 0:
+            combo.setCurrentIndex(index)
+
+    def _find_index_by_data(self, combo: QComboBox, value: object) -> int:
+        for idx in range(combo.count()):
+            if combo.itemData(idx) == value:
+                return idx
+        return -1
+
+    def _normalize_size_value(self, value: str) -> str:
+        cleaned = value.strip()
+        if not cleaned:
+            return "auto"
+        lowered = cleaned.lower().replace("×", "x")
+        mapping = {
+            "1024x1024 (quadrado)": "1024x1024",
+            "1536x1024 (paisagem)": "1536x1024",
+            "1024x1536 (retrato)": "1024x1536",
+            "auto (padrão)": "auto",
+            "auto": "auto",
+            "1024x1024": "1024x1024",
+            "1536x1024": "1536x1024",
+            "1024x1536": "1024x1536",
+            "1080x1350 (retrato)": "1024x1536",
+            "1080x1920 (vertical/short)": "1024x1536",
+            "1920x1080 (paisagem)": "1536x1024",
+        }
+        if lowered in mapping:
+            return mapping[lowered]
+        match = re.search(r"(\d{3,4})x(\d{3,4})", lowered)
+        if match:
+            return f"{match.group(1)}x{match.group(2)}"
+        return cleaned
+
+    def _normalize_resolution_value(self, value: str) -> str:
+        cleaned = value.strip().lower()
+        mapping = {
+            "low": "low",
+            "medium": "medium",
+            "high": "high",
+            "auto": "auto",
+            "auto (padrão)": "auto",
+            "baixa": "low",
+            "média": "medium",
+            "media": "medium",
+            "alta": "high",
+        }
+        return mapping.get(cleaned, cleaned)

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -278,6 +278,10 @@ class MainWindow(QMainWindow):
             self.promptSubmitted.emit(text)
 
     # Public helpers -----------------------------------------------------
+    def selected_files(self) -> list[Path]:
+        """Return the currently selected media files."""
+        return [Path(path) for path in sorted(self._selected_paths)]
+
     def set_source_folder(self, folder: Path) -> None:
         path_label = getattr(self.sourcePanel, "pathLabel", None)
         if path_label is not None:

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from math import ceil
 from typing import Callable, Iterable
 
-from PyQt6.QtCore import QEvent, QSize, Qt, pyqtSignal
+from PyQt6.QtCore import QEvent, QSize, Qt, QTimer, pyqtSignal
 from PyQt6.QtGui import QIcon, QPixmap
 from PyQt6.QtWidgets import (
     QFileDialog,
@@ -45,6 +45,10 @@ class MainWindow(QMainWindow):
         self._selected_paths: set[str] = set()
         self._text_lists: list[QListWidget] = []
         self._max_text_rows = 4
+        self._generation_timer = QTimer(self)
+        self._generation_timer.setInterval(1000)
+        self._generation_timer.timeout.connect(self._update_generation_progress)
+        self._generation_elapsed = 0
         self._setup_ui()
 
     def _setup_ui(self) -> None:
@@ -87,6 +91,7 @@ class MainWindow(QMainWindow):
 
         composer = self._create_composer()
         center_layout.addWidget(composer)
+        self._composer = composer
 
         center_layout.setStretch(0, 0)
         center_layout.setStretch(1, 1)
@@ -270,12 +275,71 @@ class MainWindow(QMainWindow):
         actions.addStretch(1)
         actions.addWidget(generate)
         layout.addLayout(actions)
+
+        progress = QLabel()
+        progress.setObjectName("ComposerProgressLabel")
+        progress.setVisible(False)
+        layout.addWidget(progress)
+
+        frame.generateButton = generate  # type: ignore[attr-defined]
+        frame.progressLabel = progress  # type: ignore[attr-defined]
         return frame
 
     def _emit_prompt(self) -> None:
         text = self.promptEdit.toPlainText().strip()
         if text:
             self.promptSubmitted.emit(text)
+
+    def begin_generation_progress(self) -> None:
+        composer_widget: QWidget | None = getattr(self, "_composer", None)
+        generate_button: QPushButton | None = None
+        progress_label: QLabel | None = None
+        if composer_widget is not None:
+            generate_button = getattr(composer_widget, "generateButton", None)
+            progress_label = getattr(composer_widget, "progressLabel", None)
+
+        if generate_button is not None:
+            generate_button.setEnabled(False)
+
+        if progress_label is not None:
+            self._generation_elapsed = 0
+            progress_label.setText("Gerando conteúdo… 0 s")
+            progress_label.setVisible(True)
+            self._generation_timer.start()
+
+    def finish_generation_progress(self, *, message: str | None = None) -> None:
+        if self._generation_timer.isActive():
+            self._generation_timer.stop()
+
+        composer_widget: QWidget | None = getattr(self, "_composer", None)
+        generate_button: QPushButton | None = None
+        progress_label: QLabel | None = None
+        if composer_widget is not None:
+            generate_button = getattr(composer_widget, "generateButton", None)
+            progress_label = getattr(composer_widget, "progressLabel", None)
+
+        if generate_button is not None:
+            generate_button.setEnabled(True)
+
+        if progress_label is not None:
+            if message:
+                progress_label.setText(message)
+                progress_label.setVisible(True)
+            else:
+                progress_label.setVisible(False)
+                return
+
+    def _update_generation_progress(self) -> None:
+        self._generation_elapsed += 1
+        composer_widget = getattr(self, "_composer", None)
+        if composer_widget is None:
+            return
+        progress_label: QLabel | None = getattr(composer_widget, "progressLabel", None)
+        if progress_label is None:
+            return
+        progress_label.setText(
+            f"Gerando conteúdo… {self._generation_elapsed} s"
+        )
 
     # Public helpers -----------------------------------------------------
     def selected_files(self) -> list[Path]:


### PR DESCRIPTION
## Summary
- strip the application controller of all OpenAI client setup and request logic, keeping only UI orchestration
- notify the user that API integration is unavailable when attempting to generate music content

## Testing
- python -m compileall core ui

------
https://chatgpt.com/codex/tasks/task_e_69054ab202708326bab190788ef264f4